### PR TITLE
DTBook imggroup with only one image will not be wrapped in image-series

### DIFF
--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -3683,6 +3683,30 @@
                         </choice>
                     </zeroOrMore>
                     
+                    <!-- group + oneOrMore = two or more -->
+                    <group>
+                        <element name="figure">
+                            <ref name="attlist.imggroup"/>
+                            <zeroOrMore>
+                                <choice>
+                                    <ref name="pagenum.span"/> <!-- span -->
+                                    <ref name="prodnote"/> <!-- aside -->
+                                </choice>
+                            </zeroOrMore>
+                            
+                            <ref name="img"/> <!-- img -->
+                            <optional>
+                                <ref name="caption.figure"/> <!-- figcaption -->
+                            </optional>
+                        </element>
+                        
+                        <zeroOrMore>
+                            <choice>
+                                <ref name="pagenum.span"/> <!-- span -->
+                                <ref name="prodnote"/> <!-- aside -->
+                            </choice>
+                        </zeroOrMore>
+                    </group>
                     <oneOrMore>
                         
                         <element name="figure">

--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -4,7 +4,7 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:pf="http://www.daisy.org/ns/pipeline/functions">
 
     <xsl:import href="http://www.daisy.org/pipeline/modules/common-utils/numeral-conversion.xsl"/>
-    <!--        <xsl:import href="../../../../test/xspec/mock/numeral-conversion.xsl"/>-->
+    <!--    <xsl:import href="../../../../test/xspec/mock/numeral-conversion.xsl"/>-->
 
     <xsl:output indent="yes" exclude-result-prefixes="#all"/>
 
@@ -973,49 +973,62 @@
             </xsl:choose>
             <xsl:apply-templates select="$imggroup-trailing-content"/>
 
-            <xsl:for-each select="dtbook:img">
-                <xsl:variable name="captions"
-                    select="if (not(following-sibling::dtbook:caption)) then () else following-sibling::node()[not(self::text())] intersect (if (following-sibling::dtbook:img) then (following-sibling::dtbook:img[1]/preceding-sibling::dtbook:caption[1]/(. | preceding-sibling::node()[not(self::text())])) else (following-sibling::dtbook:caption[last()]/(. | preceding-sibling::node()[not(self::text())])))"/>
-                <xsl:variable name="trailing-content"
-                    select="(if ($captions) then $captions[last()] else .)/following-sibling::node()[not(self::text())] intersect (if (following-sibling::dtbook:img) then following-sibling::dtbook:img[1]/preceding-sibling::node()[not(self::text())] else following-sibling::node())"/>
-                <figure class="image">
-                    <xsl:apply-templates select="."/>
-                    <xsl:choose>
-                        <xsl:when test="count($captions[self::*]) = 1">
-                            <figcaption>
-                                <xsl:for-each select="$captions">
+            <xsl:choose>
+                <xsl:when test="count(dtbook:img) &gt; 1">
+                    <xsl:for-each select="dtbook:img">
+                        <figure class="image">
+                            <xsl:call-template name="imggroup.image"/>
+                        </figure>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:for-each select="dtbook:img">
+                        <xsl:call-template name="imggroup.image"/>
+                    </xsl:for-each>
+                </xsl:otherwise>
+            </xsl:choose>
+        </figure>
+    </xsl:template>
+
+    <xsl:template name="imggroup.image">
+        <xsl:variable name="captions"
+            select="if (not(following-sibling::dtbook:caption)) then () else following-sibling::node()[not(self::text())] intersect (if (following-sibling::dtbook:img) then (following-sibling::dtbook:img[1]/preceding-sibling::dtbook:caption[1]/(. | preceding-sibling::node()[not(self::text())])) else (following-sibling::dtbook:caption[last()]/(. | preceding-sibling::node()[not(self::text())])))"/>
+        <xsl:variable name="trailing-content"
+            select="(if ($captions) then $captions[last()] else .)/following-sibling::node()[not(self::text())] intersect (if (following-sibling::dtbook:img) then following-sibling::dtbook:img[1]/preceding-sibling::node()[not(self::text())] else following-sibling::node())"/>
+        <xsl:apply-templates select="."/>
+        <xsl:choose>
+            <xsl:when test="count($captions[self::*]) = 1">
+                <figcaption>
+                    <xsl:for-each select="$captions">
+                        <xsl:call-template name="attlist.caption"/>
+                        <xsl:apply-templates select="."/>
+                    </xsl:for-each>
+                </figcaption>
+            </xsl:when>
+            <xsl:when test="count($captions[self::*]) &gt; 1">
+                <figcaption>
+                    <xsl:for-each select="$captions">
+                        <xsl:choose>
+                            <xsl:when test="self::dtbook:caption">
+                                <div>
                                     <xsl:call-template name="attlist.caption"/>
                                     <xsl:apply-templates select="."/>
-                                </xsl:for-each>
-                            </figcaption>
-                        </xsl:when>
-                        <xsl:when test="count($captions[self::*]) &gt; 1">
-                            <figcaption>
-                                <xsl:for-each select="$captions">
-                                    <xsl:choose>
-                                        <xsl:when test="self::dtbook:caption">
-                                            <div>
-                                                <xsl:call-template name="attlist.caption"/>
-                                                <xsl:apply-templates select="."/>
-                                            </div>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:apply-templates select="."/>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </xsl:for-each>
-                            </figcaption>
-                        </xsl:when>
-                    </xsl:choose>
-                </figure>
-                <xsl:apply-templates select="$trailing-content"/>
-            </xsl:for-each>
-        </figure>
+                                </div>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:apply-templates select="."/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:for-each>
+                </figcaption>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates select="$trailing-content"/>
     </xsl:template>
 
     <xsl:template name="attlist.imggroup">
         <xsl:call-template name="attrs">
-            <xsl:with-param name="classes" select="'image-series'" tunnel="yes"/>
+            <xsl:with-param name="classes" select="if (count(dtbook:img) &gt; 1) then 'image-series' else 'image'" tunnel="yes"/>
         </xsl:call-template>
     </xsl:template>
 

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -1252,15 +1252,13 @@
                 </dtbook:imggroup>
             </x:context>
             <x:expect label="the resulting element should be a figure">
-                <html:figure id="..." class="image-series">
+                <html:figure id="..." class="image">
                     <html:aside id="prodnote1" epub:type="z3998:production"/>
-                    <html:figure class="image">
-                        <html:img src="images/img.jpg" id="img1" longdesc="#prodnote1" alt="image"/>
-                        <html:figcaption>
-                            <html:span epub:type="pagebreak" class="page-normal" title="1"/>
-                            <html:div id="caption1"/>
-                        </html:figcaption>
-                    </html:figure>
+                    <html:img src="images/img.jpg" id="img1" longdesc="#prodnote1" alt="image"/>
+                    <html:figcaption>
+                        <html:span epub:type="pagebreak" class="page-normal" title="1"/>
+                        <html:div id="caption1"/>
+                    </html:figcaption>
                 </html:figure>
             </x:expect>
         </x:scenario>
@@ -3189,10 +3187,8 @@
         <x:expect label="the p should be converted into a div and any text before and after the imggroup should be wrapped in new p elements (img without imggroup is allowed in p)">
             <html:div>
                 <html:div xml:lang="no" lang="no" id="id1" class="class1">
-                    <html:figure id="..." class="image-series">
-                        <html:figure class="image">
-                            <html:img id="rId101" src="images/900340%20(Reparert)-Picture%201.png" alt=""/>
-                        </html:figure>
+                    <html:figure id="..." class="image">
+                        <html:img id="rId101" src="images/900340%20(Reparert)-Picture%201.png" alt=""/>
                     </html:figure>
                 </html:div>
                 <html:p xml:lang="no" lang="no" id="id2" class="class2">
@@ -3200,17 +3196,15 @@
                 </html:p>
                 <html:div xml:lang="no" lang="no" id="id3" class="class3">
                     <html:p>TEXT</html:p>
-                    <html:figure id="..." class="image-series">
-                        <html:figure class="image">
-                            <html:img id="rId101" src="images/900340%20(Reparert)-Picture%201.png" alt=""/>
-                        </html:figure>
+                    <html:figure id="..." class="image">
+                        <html:img id="rId101" src="images/900340%20(Reparert)-Picture%201.png" alt=""/>
                     </html:figure>
                     <html:p>TEXT</html:p>
                 </html:div>
             </html:div>
         </x:expect>
     </x:scenario>
-    
+
     <x:scenario label="when processing a li element enumerated with letters of with a string length &gt; 1">
         <x:context>
             <dtbook:list type="pl" depth="1">


### PR DESCRIPTION
- added RNG restriction: image series must have at least two images
- DTBook imggroup with only one image will not be wrapped in image-series
- updated xslt tests

fixes #57
