### PR TITLE
improved conversion of lists

### DIFF
--- a/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
+++ b/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
@@ -1077,6 +1077,7 @@
             <xsl:call-template name="attlist.li"/>
             <xsl:variable name="marker">
                 <xsl:choose>
+                    <xsl:when test="parent::html:*/f:classes(.)='list-style-type-none'"/>
                     <xsl:when test="parent::html:ul">
                         <xsl:value-of select="'• '"/>
                     </xsl:when>
@@ -1094,14 +1095,10 @@
                         <xsl:variable name="roman" select="pf:numeric-decimal-to-roman($value)"/>
                         <xsl:value-of select="concat(if (parent::html:ol/@type='i') then lower-case($roman) else upper-case($roman),'. ')"/>
                     </xsl:when>
-                    <xsl:otherwise>
-                        <!-- shouldn't happen, but let's have a fallback anyway -->
-                        <xsl:value-of select="'• '"/>
-                    </xsl:otherwise>
                 </xsl:choose>
             </xsl:variable>
             <xsl:variable name="is-block"
-                select="if ((html:figure | html:p | html:ol | html:ul | html:dl | html:div | html:blockquote | html:table | html:address | html:section | html:aside)) then true() else false()"/>
+                select="if ((html:p | html:ol | html:ul | html:dl | html:div | html:blockquote | html:table | html:address | html:section | html:aside)) then true() else false()"/>
             <xsl:choose>
                 <xsl:when test="$is-block">
                     <xsl:choose>

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -1470,7 +1470,7 @@
                     <html:p>
                         <html:span>A</html:span>
                     </html:p>
-                    <html:ol id="..."/>
+                    <html:ol id="..." class="list-style-type-none"/>
                     <html:p>
                         <html:span>B</html:span>
                     </html:p>
@@ -2274,7 +2274,7 @@
                 </dtbook:list>
             </x:context>
             <x:expect label="the resulting element should be a ol">
-                <html:ol id="...">
+                <html:ol id="..." class="list-style-type-none">
                     <html:li id="...">TEXT</html:li>
                 </html:ol>
             </x:expect>
@@ -2286,7 +2286,7 @@
                 </dtbook:list>
             </x:context>
             <x:expect label="the resulting element should be a ol (the type attribute is ignored since it is disallowed in nordic guidelines)">
-                <html:ol id="...">
+                <html:ol id="..." class="list-style-type-none">
                     <html:li id="...">TEXT</html:li>
                 </html:ol>
             </x:expect>
@@ -2298,7 +2298,7 @@
                 </dtbook:list>
             </x:context>
             <x:expect label="the resulting element should be a ol">
-                <html:ol id="...">
+                <html:ol id="..." class="list-style-type-none">
                     <html:li id="...">TEXT</html:li>
                 </html:ol>
             </x:expect>
@@ -2313,7 +2313,7 @@
             </dtbook:list>
         </x:context>
         <x:expect label="the resulting list should be wrapped in a section element">
-            <html:ol id="..." start="1">
+            <html:ol id="..." start="1" class="list-style-type-none">
                 <html:li id="...">TEXT</html:li>
             </html:ol>
         </x:expect>
@@ -3154,13 +3154,13 @@
             </dtbook:list>
         </x:context>
         <x:expect label="the resulting toc should be as given">
-            <html:ol id="..." epub:type="toc">
+            <html:ol id="..." epub:type="toc" class="list-style-type-none">
                 <html:li id="...">
                     <html:span class="lic">
                         <html:strong>Kapittel 1 Vitenskap: grunnleggende antakelser</html:strong>
                     </html:span>
                     <html:span class="lic">13</html:span>
-                    <html:ol id="...">
+                    <html:ol id="..." class="list-style-type-none">
                         <html:li id="...">
                             <html:span class="lic">Hva er vitenskap?</html:span>
                             <html:span class="lic">14</html:span>
@@ -3176,13 +3176,13 @@
                         <html:strong>Del 1 Grunnleggende begreper og prinsipper</html:strong>
                     </html:span>
                     <html:span class="lic">39</html:span>
-                    <html:ol id="...">
+                    <html:ol id="..." class="list-style-type-none">
                         <html:li id="...">
                             <html:span class="lic">
                                 <html:strong><![CDATA[Kapittel 2 Vitenskapelig tenkning: validitet, begreper og teori]]></html:strong>
                             </html:span>
                             <html:span class="lic">41</html:span>
-                            <html:ol id="...">
+                            <html:ol id="..." class="list-style-type-none">
                                 <html:li id="...">
                                     <html:span class="lic">Validitet</html:span>
                                     <html:span class="lic">41</html:span>
@@ -3198,7 +3198,7 @@
                                 <html:strong><![CDATA[Kapittel 3 Forskningsprosessen: fra spørsmål til svar]]></html:strong>
                             </html:span>
                             <html:span class="lic">70</html:span>
-                            <html:ol id="...">
+                            <html:ol id="..." class="list-style-type-none">
                                 <html:li id="...">
                                     <html:span class="lic"><![CDATA[Hvor kommer ideer til forskning fra?]]></html:span>
                                     <html:span class="lic">71</html:span>
@@ -3407,6 +3407,66 @@
         </x:context>
         <x:expect label="the span class 'asciimath' should be preserved">
             <html:span class="asciimath"/>
+        </x:expect>
+    </x:scenario>
+
+    <x:scenario label="List items with both inline and imggroup content, and no bullets or numbering">
+        <x:context>
+            <dtbook:list type="pl">
+                <dtbook:li><dtbook:strong>Totalt antal häckande par</dtbook:strong> 49 024 037–101 782 306</dtbook:li>
+                <dtbook:li><dtbook:strong>Antal ökande arter</dtbook:strong> 64</dtbook:li>
+                <dtbook:li><dtbook:strong>Procentandel ökande arter</dtbook:strong> 26%</dtbook:li>
+                <dtbook:li><dtbook:strong>Antal minskande arter</dtbook:strong> 114</dtbook:li>
+                <dtbook:li><dtbook:strong>Procentandel minskande arter</dtbook:strong> 46%</dtbook:li>
+                <dtbook:li><dtbook:strong>Sommarhalvåret</dtbook:strong>
+                    <dtbook:imggroup>
+                        <dtbook:img src="img01.jpg" alt="illustration"/>
+                    </dtbook:imggroup> (vissa arter kan sällsynt övervintra)</dtbook:li>
+                <dtbook:li><dtbook:strong>Hela året</dtbook:strong>
+                    <dtbook:imggroup>
+                        <dtbook:img src="img02.jpg" alt="illustration"/>
+                    </dtbook:imggroup></dtbook:li>
+                <dtbook:li><dtbook:strong>Vinterhalvåret</dtbook:strong>
+                    <dtbook:imggroup>
+                        <dtbook:img src="img03.jpg" alt="illustration"/>
+                    </dtbook:imggroup></dtbook:li>
+                <dtbook:li><dtbook:strong>ökande bestånd</dtbook:strong> ↗</dtbook:li>
+                <dtbook:li><dtbook:strong>minskande bestånd</dtbook:strong> ↘</dtbook:li>
+                <dtbook:li><dtbook:strong>stabilt bestånd</dtbook:strong> →</dtbook:li>
+                <dtbook:li><dtbook:strong>fluktuerande bestånd</dtbook:strong> ~</dtbook:li>
+                <dtbook:li><dtbook:strong>beståndsutveckling osäker</dtbook:strong>‽</dtbook:li>
+            </dtbook:list>
+        </x:context>
+        <x:expect label="the result should be as expected">
+            <html:ol id="..." class="list-style-type-none">
+                <html:li id="..."><html:strong>Totalt antal häckande par</html:strong> 49 024 037–101 782 306</html:li>
+                <html:li id="..."><html:strong>Antal ökande arter</html:strong> 64</html:li>
+                <html:li id="..."><html:strong>Procentandel ökande arter</html:strong> 26%</html:li>
+                <html:li id="..."><html:strong>Antal minskande arter</html:strong> 114</html:li>
+                <html:li id="..."><html:strong>Procentandel minskande arter</html:strong> 46%</html:li>
+                <html:li id="...">
+                    <html:strong>Sommarhalvåret</html:strong>
+                    <html:figure id="..." class="image">
+                        <html:img id="..." src="images/img01.jpg" alt="image"/>
+                    </html:figure> (vissa arter kan sällsynt övervintra)</html:li>
+                <html:li id="...">
+                    <html:strong>Hela året</html:strong>
+                    <html:figure id="..." class="image">
+                        <html:img id="..." src="images/img02.jpg" alt="image"/>
+                    </html:figure>
+                </html:li>
+                <html:li id="...">
+                    <html:strong>Vinterhalvåret</html:strong>
+                    <html:figure id="..." class="image">
+                        <html:img id="..." src="images/img03.jpg" alt="image"/>
+                    </html:figure>
+                </html:li>
+                <html:li id="..."><html:strong>ökande bestånd</html:strong> ↗</html:li>
+                <html:li id="..."><html:strong>minskande bestånd</html:strong> ↘</html:li>
+                <html:li id="..."><html:strong>stabilt bestånd</html:strong> →</html:li>
+                <html:li id="..."><html:strong>fluktuerande bestånd</html:strong> ~</html:li>
+                <html:li id="..."><html:strong>beståndsutveckling osäker</html:strong>‽</html:li>
+            </html:ol>
         </x:expect>
     </x:scenario>
 

--- a/src/test/xspec/epub3-to-dtbook.xspec
+++ b/src/test/xspec/epub3-to-dtbook.xspec
@@ -1742,8 +1742,8 @@
             <x:context>
                 <html:li/>
             </x:context>
-            <x:expect label="the resulting element should be a li and its contents should be prepended with '• ' since it is part of a preformatted list (all nordic lists are required to be so)">
-                <dtbook:li>• </dtbook:li>
+            <x:expect label="the resulting element should be a li">
+                <dtbook:li/>
             </x:expect>
         </x:scenario>
         <x:scenario label="with ul and both block and non-block text content">
@@ -2348,6 +2348,66 @@
         </x:context>
         <x:expect label="the span class 'asciimath' should be preserved">
             <dtbook:span class="asciimath"/>
+        </x:expect>
+    </x:scenario>
+
+    <x:scenario label="List items with both inline and image (figure) content, and no bullets or numbering">
+        <x:context>
+            <html:ol class="list-style-type-none">
+                <html:li><html:strong>Totalt antal häckande par</html:strong> 49 024 037–101 782 306</html:li>
+                <html:li><html:strong>Antal ökande arter</html:strong> 64</html:li>
+                <html:li><html:strong>Procentandel ökande arter</html:strong> 26%</html:li>
+                <html:li><html:strong>Antal minskande arter</html:strong> 114</html:li>
+                <html:li><html:strong>Procentandel minskande arter</html:strong> 46%</html:li>
+                <html:li>
+                    <html:strong>Sommarhalvåret</html:strong>
+                    <html:figure class="image">
+                        <html:img src="images/img01.jpg" alt="image"/>
+                    </html:figure> (vissa arter kan sällsynt övervintra)</html:li>
+                <html:li>
+                    <html:strong>Hela året</html:strong>
+                    <html:figure class="image">
+                        <html:img src="images/img02.jpg" alt="image"/>
+                    </html:figure>
+                </html:li>
+                <html:li>
+                    <html:strong>Vinterhalvåret</html:strong>
+                    <html:figure class="image">
+                        <html:img src="images/img03.jpg" alt="image"/>
+                    </html:figure>
+                </html:li>
+                <html:li><html:strong>ökande bestånd</html:strong> ↗</html:li>
+                <html:li><html:strong>minskande bestånd</html:strong> ↘</html:li>
+                <html:li><html:strong>stabilt bestånd</html:strong> →</html:li>
+                <html:li><html:strong>fluktuerande bestånd</html:strong> ~</html:li>
+                <html:li><html:strong>beståndsutveckling osäker</html:strong>‽</html:li>
+            </html:ol>
+        </x:context>
+        <x:expect label="the result should be as expected">
+            <dtbook:list type="pl" depth="1">
+                <dtbook:li><dtbook:strong>Totalt antal häckande par</dtbook:strong> 49 024 037–101 782 306</dtbook:li>
+                <dtbook:li><dtbook:strong>Antal ökande arter</dtbook:strong> 64</dtbook:li>
+                <dtbook:li><dtbook:strong>Procentandel ökande arter</dtbook:strong> 26%</dtbook:li>
+                <dtbook:li><dtbook:strong>Antal minskande arter</dtbook:strong> 114</dtbook:li>
+                <dtbook:li><dtbook:strong>Procentandel minskande arter</dtbook:strong> 46%</dtbook:li>
+                <dtbook:li><dtbook:strong>Sommarhalvåret</dtbook:strong>
+                    <dtbook:imggroup>
+                        <dtbook:img src="img01.jpg" alt="image" id="..."/>
+                    </dtbook:imggroup> (vissa arter kan sällsynt övervintra)</dtbook:li>
+                <dtbook:li><dtbook:strong>Hela året</dtbook:strong>
+                    <dtbook:imggroup>
+                        <dtbook:img src="img02.jpg" alt="image" id="..."/>
+                    </dtbook:imggroup></dtbook:li>
+                <dtbook:li><dtbook:strong>Vinterhalvåret</dtbook:strong>
+                    <dtbook:imggroup>
+                        <dtbook:img src="img03.jpg" alt="image" id="..."/>
+                    </dtbook:imggroup></dtbook:li>
+                <dtbook:li><dtbook:strong>ökande bestånd</dtbook:strong> ↗</dtbook:li>
+                <dtbook:li><dtbook:strong>minskande bestånd</dtbook:strong> ↘</dtbook:li>
+                <dtbook:li><dtbook:strong>stabilt bestånd</dtbook:strong> →</dtbook:li>
+                <dtbook:li><dtbook:strong>fluktuerande bestånd</dtbook:strong> ~</dtbook:li>
+                <dtbook:li><dtbook:strong>beståndsutveckling osäker</dtbook:strong>‽</dtbook:li>
+            </dtbook:list>
         </x:expect>
     </x:scenario>
 


### PR DESCRIPTION
- added class 'list-style-type-none' for lists with no bullets or numbers
- improved conversion of 'li' elements from dtbook to html (fixes cases where block elements were created as siblings to inline elements)
- figure element are now allowed inline (at least in some cases?)
- added tests with lists containing figures, text and inline elements as siblings
