### PR TITLE
epub3-to-dtbook: fixed error with multiple classes on the same p (FORG0006)

### DIFF
--- a/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
+++ b/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
@@ -929,7 +929,7 @@
         <xsl:param name="classes" select="()" tunnel="yes"/>
         <xsl:variable name="classes"
             select="(for $class in ((tokenize(@class,'\s'),$classes)) return if ($class = ('part','jacketcopy','colophon','nonstandardpagination','indented')) then $class else (), if (preceding-sibling::*[1] intersect preceding-sibling::html:hr[1]) then (if (preceding-sibling::html:hr[1]/tokenize(@class,'\s')='separator') then 'precedingseparator' else 'precedingemptyline') else ())"/>
-        <xsl:if test="$classes">
+        <xsl:if test="count($classes)">
             <xsl:attribute name="class" select="string-join($classes,' ')"/>
         </xsl:if>
     </xsl:template>

--- a/src/test/xspec/epub3-to-dtbook.xspec
+++ b/src/test/xspec/epub3-to-dtbook.xspec
@@ -2272,8 +2272,6 @@
         </x:expect>
     </x:scenario>
 
-    <!-- ########## Nordic tests ########## -->
-
     <x:scenario label="github issue #30; make images in swedish books have alt='illustration'">
         <x:scenario label="when there's no conflicting ancestor language">
             <x:context>
@@ -2408,6 +2406,16 @@
                 <dtbook:li><dtbook:strong>fluktuerande bestånd</dtbook:strong> ~</dtbook:li>
                 <dtbook:li><dtbook:strong>beståndsutveckling osäker</dtbook:strong>‽</dtbook:li>
             </dtbook:list>
+        </x:expect>
+    </x:scenario>
+
+    <x:scenario label="err:FORG0006 when declaring multiple classes">
+        <x:context>
+            <html:hr class="emptyline"/>
+            <html:p class="indented">TEXT</html:p>
+        </x:context>
+        <x:expect label="the resulting class attribute should not throw an error">
+            <dtbook:p class="indented precedingemptyline">TEXT</dtbook:p>
         </x:expect>
     </x:scenario>
 


### PR DESCRIPTION
This would throw a FORG0006 error, but is now fixed:

``` html
<hr class="emptyline"/>
<p class="indented">TEXT</p>
```

The result in DTBook contains multiple classes and should be:

``` xml
<p class="indented precedingemptyline">TEXT</p>
```
