### PR TITLE
improved pagebreak error messages and fixed xmlns:nordic error

### DIFF
--- a/src/main/resources/xml/schema/nordic2015-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/nordic2015-1.opf-and-html.sch
@@ -34,4 +34,36 @@
         </rule>
     </pattern>
 
+    <!-- Rule 40: No page numbering gaps for pagebreak w/page-normal -->
+    <pattern id="dtbook_TPB_40">
+        <rule
+            context="html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal' and count(preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal'])]">
+            <let name="preceding-pagebreak" value="preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal'][1]"/>
+            <report test="number($preceding-pagebreak/@title) != number(@title)-1">[tpb40b] No gaps may occur in page numbering (see pagebreak with title="<value-of select="@title"/>" in <value-of
+                    select="replace(base-uri(.),'^.*/','')"/> and compare with pagebreak with title="<value-of select="$preceding-pagebreak/@title"/>" in <value-of
+                    select="replace(base-uri($preceding-pagebreak),'^.*/','')"/>)</report>
+        </rule>
+    </pattern>
+
+    <!-- Rule 23: Increasing pagebreak values for page-normal -->
+    <pattern id="dtbook_TPB_23">
+        <rule
+            context="html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal' and preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak'][tokenize(@class,'\s+')='page-normal']]">
+            <let name="preceding" value="preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal'][1]"/>
+            <assert test="number(current()/@title) > number($preceding/@title)">[tpb23] pagebreak values must increase for pagebreaks with class="page-normal" (see pagebreak with title="<value-of
+                    select="@title"/>" in <value-of select="replace(base-uri(.),'^.*/','')"/> and compare with pagebreak with title="<value-of select="$preceding/@title"/> in <value-of
+                    select="replace(base-uri($preceding),'^.*/','')"/>)</assert>
+        </rule>
+    </pattern>
+
+    <!-- Rule 24: Values of pagebreak must be unique for page-front -->
+    <pattern id="dtbook_TPB_24">
+        <rule context="html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-front']">
+            <assert test="count(//html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-front' and @title=current()/@title])=1">[tpb24] pagebreak values must be unique for
+                pagebreaks with class="page-front" (see pagebreak with title="<value-of select="@title"/>" in <value-of select="replace(base-uri(.),'^.*/','')"/>)</assert>
+        </rule>
+    </pattern>
+
+
+
 </schema>

--- a/src/main/resources/xml/schema/nordic2015-1.sch
+++ b/src/main/resources/xml/schema/nordic2015-1.sch
@@ -132,18 +132,18 @@
     <!-- Rule 23: Increasing pagebreak values for page-normal -->
     <sch:pattern id="dtbook_TPB_23">
         <sch:rule
-            context="html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-normal' and preceding::html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-normal']]">
-            <sch:assert test="number(current()/@title) > number(preceding::html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-normal'][1]/@title)">[tpb23] pagebreak values must
-                increase for page-normal</sch:assert>
+            context="html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal' and preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak'][tokenize(@class,'\s+')='page-normal']]">
+            <sch:let name="preceding" value="preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal'][1]"/>
+            <sch:assert test="number(current()/@title) > number($preceding/@title)">[tpb23] pagebreak values must increase for pagebreaks with class="page-normal" (see pagebreak with
+                    title="<sch:value-of select="@title"/>" and compare with pagebreak with title="<sch:value-of select="$preceding/@title"/>")</sch:assert>
         </sch:rule>
     </sch:pattern>
 
     <!-- Rule 24: Values of pagebreak must be unique for page-front -->
     <sch:pattern id="dtbook_TPB_24">
         <sch:rule context="html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-front']">
-            <!--  		<sch:assert test="count(key('pageFrontValues', .))=1">[tpb24] pagebreak values must be unique for page-front</sch:assert>-->
-            <sch:assert test="count(//html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-front' and @title=current()/@title])=1">[tpb24] pagebreak values must be unique for
-                page-front</sch:assert>
+            <sch:assert test="count(//html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-front' and @title=current()/@title])=1">[tpb24] pagebreak values must be unique for
+                pagebreaks with class="page-front" (see pagebreak with title="<sch:value-of select="@title"/>")</sch:assert>
         </sch:rule>
     </sch:pattern>
 
@@ -237,10 +237,11 @@
 
     <!-- Rule 40: No page numbering gaps for pagebreak w/page-normal -->
     <sch:pattern id="dtbook_TPB_40">
-        <sch:rule context="html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-normal']">
-            <sch:report
-                test="preceding::html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-normal'] and number(preceding::html:*[tokenize(@epub:type,' ')='pagebreak'][tokenize(@class,' ')='page-normal'][1]/@title) != number(@title)-1"
-                >[tpb40] No gaps may occur in page numbering</sch:report>
+        <sch:rule
+            context="html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal' and count(preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal'])]">
+            <sch:let name="preceding-pagebreak" value="preceding::html:*[tokenize(@epub:type,'\s+')='pagebreak' and tokenize(@class,'\s+')='page-normal'][1]"/>
+            <sch:report test="number($preceding-pagebreak/@title) != number(@title)-1">[tpb40a] No gaps may occur in page numbering (see pagebreak with title="<sch:value-of select="@title"/>" and
+                compare with pagebreak with title="<sch:value-of select="$preceding-pagebreak/@title"/>")</sch:report>
         </sch:rule>
     </sch:pattern>
 

--- a/src/main/resources/xml/xproc/step/epub3.validate.xpl
+++ b/src/main/resources/xml/xproc/step/epub3.validate.xpl
@@ -152,15 +152,24 @@
     <p:identity name="opf"/>
     <p:sink/>
 
-    <px:fileset-load media-types="application/xhtml+xml">
-        <p:input port="fileset">
-            <p:pipe port="fileset" step="unzip"/>
+    <p:xslt>
+        <!-- get fileset of HTML documents in spine order -->
+        <p:input port="parameters">
+            <p:empty/>
         </p:input>
+        <p:input port="source">
+            <p:pipe port="result" step="opf"/>
+        </p:input>
+        <p:input port="stylesheet">
+            <p:document href="../../xslt/opf-to-spine-fileset.xsl"/>
+        </p:input>
+    </p:xslt>
+    <px:fileset-load media-types="application/xhtml+xml">
         <p:input port="in-memory">
             <p:pipe port="in-memory" step="unzip"/>
         </p:input>
     </px:fileset-load>
-    <px:assert test-count-min="1" message="There must be a HTML file in the fileset." error-code="NORDICDTBOOKEPUB005"/>
+    <px:assert test-count-min="1" message="There must be a HTML file in the spine." error-code="NORDICDTBOOKEPUB005"/>
     <p:identity name="html"/>
     <p:sink/>
 

--- a/src/main/resources/xml/xslt/navdoc-to-outline.xsl
+++ b/src/main/resources/xml/xslt/navdoc-to-outline.xsl
@@ -2,7 +2,7 @@
     xpath-default-namespace="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" exclude-result-prefixes="#all">
 
     <xsl:import href="http://www.daisy.org/pipeline/modules/file-utils/uri-functions.xsl"/>
-<!--    <xsl:import href="../../../../test/xspec/mock/uri-functions.xsl"/>-->
+    <!--    <xsl:import href="../../../../test/xspec/mock/uri-functions.xsl"/>-->
 
     <xsl:template match="node()">
         <xsl:apply-templates select="node()"/>
@@ -12,6 +12,8 @@
         <xsl:copy>
             <xsl:attribute name="xml:base" select="base-uri(/*)"/>
             <xsl:attribute name="epub:prefix" select="'z3998: http://www.daisy.org/z3998/2012/vocab/structure/#'"/>
+            <xsl:namespace name="nordic" select="'http://www.mtm.se/epub/'"/>
+            <xsl:namespace name="epub" select="'http://www.idpf.org/2007/ops'"/>
             <head/>
             <body>
                 <xsl:apply-templates select="//nav[matches(@epub:type,'(^|\s)toc(\s|$)')]/ol"/>

--- a/src/main/resources/xml/xslt/opf-to-spine-fileset.xsl
+++ b/src/main/resources/xml/xslt/opf-to-spine-fileset.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:opf="http://www.idpf.org/2007/opf" xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all" version="2.0">
+
+    <xsl:output indent="yes"/>
+
+    <xsl:template match="/opf:package">
+        <d:fileset xml:base="{replace(base-uri(.),'^(.*/).*$','$1')}">
+            <xsl:for-each select="opf:spine/opf:itemref">
+                <xsl:variable name="idref" select="@idref"/>
+                <xsl:for-each select="/*/opf:manifest/opf:item[@id=$idref]">
+                    <d:file href="{@href}" media-type="{@media-type}"/>
+                </xsl:for-each>
+            </xsl:for-each>
+        </d:fileset>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- added validation for page numbers to opf-and-html schema, for cross-document pagebreak validation
- updated pagebreak validation rules to contain more information useful for locating the error
- epub3.validate now loads all html documents in spine order, rather than simply all HTML documents.
  - TODO: check if this has any consequence for validating the navigation document in case the navigation document is not in the spine
- added xmlns:nordic and xmlns:epub to the `<html>` element in the single-HTML representation when converting from EPUB to HTML
