### PR TITLE
allow content in titlepage, fixed usage of author and title

### DIFF
--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -593,7 +593,6 @@
                 <choice>
                     <!-- multi-page HTML -->
                     <ref name="cover"/>
-                    <ref name="frontmatter.titlepage"/>
                     <ref name="frontmatter"/>
                     <ref name="bodymatter"/>
                     <ref name="backmatter"/>
@@ -622,10 +621,7 @@
                            <element name="article">
                                <!-- "article" should be used for magazine or newspaper articles. Otherwise, "section" should be used. -->
                                <choice>
-                                   <ref name="cover"/>
-                                   <ref name="frontmatter"/>
                                    <ref name="bodymatter"/>
-                                   <ref name="backmatter"/>
                                </choice>
                            </element>
                        </choice>
@@ -755,6 +751,7 @@
   -->
     <define name="frontmatter">
         <choice>
+            <ref name="frontmatter.titlepage"/>
             <ref name="frontmatter.colophon"/>
             <ref name="frontmatter.toc"/>
             <ref name="frontmatter.foreword"/>
@@ -781,14 +778,10 @@
                 </list>
             </choice>
         </attribute>
-        <ref name="attrsrqd.notype"/>
-        <ref name="doctitle.headline"/> <!-- h1 -->
-        <optional>
-            <ref name="covertitle"/> <!-- p -->
-        </optional>
-        <zeroOrMore>
-            <ref name="docauthor"/> <!-- p -->
-        </zeroOrMore>
+        <choice>
+            <ref name="level1.only-headline"/>
+            <ref name="level1.content"/>
+        </choice>
     </define>
     <define name="frontmatter.colophon">
         <attribute name="epub:type">
@@ -3971,7 +3964,7 @@
                 <!--<value>footnotes</value>-->
                 <!--<value>foreword</value>-->
                 <!--<value>frontmatter</value>-->
-                <!--<value>fulltitle</value>-->
+                <value>fulltitle</value>
                 <!--<value>glossary</value>-->
                 <value>glossdef</value>
                 <value>glossterm</value>

--- a/src/main/resources/xml/schema/nordic2015-1.sch
+++ b/src/main/resources/xml/schema/nordic2015-1.sch
@@ -509,18 +509,10 @@
 
     <!-- Rule 135: Poem contents -->
     <sch:pattern id="dtbook_TPB_135_a">
-        <sch:rule context="html:*[tokenize(@epub:type,' ')='z3998:poem']">
-            <sch:assert test="html:*[tokenize(@class,' ')='linegroup']">[tpb135a] Every poem must contain a linegroup</sch:assert>
-            <sch:report test="html:p[tokenize(@class,' ')='line']">[tpb135a] Poem lines must be wrapped in a linegroup</sch:report>
+        <sch:rule context="html:*[tokenize(@epub:type,'\s+')='z3998:poem'] | html:*[tokenize(@epub:type,'\s+')='z3998:verse' and not(ancestor::html:*/tokenize(@epub:type,'\s+')='z3998:poem')]">
+            <sch:assert test="html:*[tokenize(@class,'\s+')='linegroup']">[nordic135] Every poem must contain a linegroup</sch:assert>
+            <sch:report test="html:p[tokenize(@class,'\s+')='line']">[nordic135] Poem lines must be wrapped in a linegroup</sch:report>
         </sch:rule>
-    </sch:pattern>
-
-    <sch:pattern id="dtbook_TPB_135_b">
-        <sch:rule context="html:*[tokenize(@epub:type,'\s+')='z3998:author']">
-            <sch:assert test="parent::html:*/tokenize(@epub:type,'\s+')='z3998:poem' or parent::html:header/parent::html:body or parent::html:body/tokenize(@epub:type,'\s+')='titlepage'">[tpb135b]
-                z3998:author is only allowed either in the titlepage or inside a poem</sch:assert>
-        </sch:rule>
-        <!-- TODO: in guidelines revision 2015-2, make sure that verses are contained in poems -->
     </sch:pattern>
 
     <!-- Rule 136: List types -->
@@ -836,12 +828,20 @@
         </sch:rule>
     </sch:pattern>
 
-    <!-- Rule 262: Only fulltitle and docauthor are allowed on the titlepage -->
-    <sch:pattern id="epub_nordic_262">
-        <sch:rule context="*[(parent::html:body|parent::html:section|parent::html:header)/tokenize(@epub:type,'\s+')='titlepage']">
-            <sch:report test="tokenize(@epub:type,'\s+')='pagebreak'">[nordic262] Pagebreaks are not allowed on the titlepage.</sch:report>
-            <sch:assert test="self::html:h1 and tokenize(@epub:type,'\s+')='fulltitle' or self::html:p and tokenize(@epub:type,'\s+')='z3998:author'">[nordic262] Only &lt;h1 epub:type="fulltitle"
-                class="title"&gt; and &lt;p epub:type="z3998:author" class="docauthor"&gt; are allowed on the titlepage.</sch:assert>
+    <!-- Rule 263: there must be a headline on the titlepage -->
+    <sch:pattern>
+        <sch:rule context="html:body[tokenize(@epub:type,'\s+')='titlepage'] | html:section[tokenize(@epub:type,'\s+')='titlepage']">
+            <sch:assert test="count(html:*[matches(local-name(),'h\d')])">[nordic263] the titlepage must have a headline (and the headline must have epub:type="fulltitle" and
+                class="title")</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+    <!-- Rule 264: h1 on titlepage must be epub:type=fulltitle with class=title -->
+    <sch:pattern>
+        <sch:rule
+            context="html:body[tokenize(@epub:type,'\s+')='titlepage']/html:*[matches(local-name(),'h\d')] | html:section[tokenize(@epub:type,'\s+')='titlepage']/html:*[matches(local-name(),'h\d')]">
+            <sch:assert test="tokenize(@epub:type,'\s+') = 'fulltitle'">[nordic264] the headline on the titlepage must have a epub:type with the value "fulltitle"</sch:assert>
+            <sch:assert test="tokenize(@class,'\s+') = 'title'">[nordic264] the headline on the titlepage must have a class with the value "title"</sch:assert>
         </sch:rule>
     </sch:pattern>
 

--- a/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
+++ b/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
@@ -331,7 +331,7 @@
         <xsl:call-template name="attrs"/>
     </xsl:template>
 
-    <xsl:template match="html:*[f:classes(.)='title']">
+    <xsl:template match="html:*[f:classes(.)='title' and not(parent::html:header[parent::html:body]) and ancestor::html:*/f:types(.)=('z3998:poem','z3998:verse')]">
         <title>
             <xsl:call-template name="attlist.title"/>
             <xsl:apply-templates select="node()"/>
@@ -344,7 +344,7 @@
         </xsl:call-template>
     </xsl:template>
 
-    <xsl:template match="html:*[f:types(.)='z3998:author' and not(parent::html:header[parent::html:body])]">
+    <xsl:template match="html:*[f:types(.)='z3998:author' and not(parent::html:header[parent::html:body]) and ancestor::html:*/f:types(.)=('z3998:poem','z3998:verse')]">
         <author>
             <xsl:call-template name="attlist.author"/>
             <xsl:apply-templates select="node()"/>
@@ -507,7 +507,7 @@
         </xsl:call-template>
     </xsl:template>
 
-    <xsl:template match="html:*[f:types(.)='z3998:poem']">
+    <xsl:template match="html:*[f:types(.)='z3998:poem'] | html:*[f:types(.)='z3998:verse' and not(ancestor::html:*/f:types(.)='z3998:poem')]">
         <poem>
             <xsl:call-template name="attlist.poem"/>
             <xsl:apply-templates select="node()"/>
@@ -516,7 +516,7 @@
 
     <xsl:template name="attlist.poem">
         <xsl:call-template name="attrs">
-            <xsl:with-param name="except-classes" select="'poem'" tunnel="yes"/>
+            <xsl:with-param name="except-classes" select="('poem','verse')" tunnel="yes"/>
         </xsl:call-template>
     </xsl:template>
 

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -214,9 +214,9 @@
                 <dtbook:book>
                     <dtbook:frontmatter>
                         <!-- COMMENT #1 -->
-                        <dtbook:level1 class="titlepage"/>
-                        <!-- COMMENT #2 -->
                         <dtbook:level1 class="cover"/>
+                        <!-- COMMENT #2 -->
+                        <dtbook:level1 class="titlepage"/>
                         <!-- COMMENT #3 -->
                         <dtbook:level1/>
                         <!-- COMMENT #4 -->
@@ -228,9 +228,9 @@
             <x:expect label="the top-level frontmatter levels should become sections and given the appropriate epub:types">
                 <html:body>
                     <!-- COMMENT #1 -->
-                    <html:section id="..." epub:type="frontmatter titlepage"/>
-                    <!-- COMMENT #2 -->
                     <html:section id="..." epub:type="cover"/>
+                    <!-- COMMENT #2 -->
+                    <html:section id="..." epub:type="frontmatter titlepage"/>
                     <!-- COMMENT #3 -->
                     <html:section id="..." epub:type="frontmatter"/>
                     <!-- COMMENT #4 -->
@@ -288,6 +288,20 @@
                     <!-- COMMENT #4 -->
                     <html:section id="..." epub:type="frontmatter"/>
                     <!-- COMMENT #5 -->
+                </html:body>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="with a jacketcopy class instead of a cover class">
+            <x:context>
+                <dtbook:book>
+                    <dtbook:frontmatter>
+                        <dtbook:level1 class="jacketcopy"/>
+                    </dtbook:frontmatter>
+                </dtbook:book>
+            </x:context>
+            <x:expect label="the result should be a cover">
+                <html:body>
+                    <html:section id="..." epub:type="cover"/>
                 </html:body>
             </x:expect>
         </x:scenario>
@@ -1531,6 +1545,8 @@
                         <dtbook:doctitle>TITLE</dtbook:doctitle>
                         <dtbook:level1 class="titlepage">
                             <dtbook:h1>OTHER TITLE</dtbook:h1>
+                            <dtbook:author>Author as direct child to titlepage (#1)</dtbook:author>
+                            <dtbook:author>Author as direct child to titlepage (#2)</dtbook:author>
                         </dtbook:level1>
                     </dtbook:frontmatter>
                 </dtbook:book>
@@ -1541,7 +1557,9 @@
                         <html:h1 id="..." epub:type="fulltitle" class="title">TITLE</html:h1>
                     </html:header>
                     <html:section id="..." epub:type="frontmatter titlepage">
-                        <html:h1 id="...">OTHER TITLE</html:h1>
+                        <html:h1 id="..." epub:type="fulltitle" class="title">OTHER TITLE</html:h1>
+                        <html:p epub:type="z3998:author" class="docauthor">Author as direct child to titlepage (#1)</html:p>
+                        <html:p epub:type="z3998:author" class="docauthor">Author as direct child to titlepage (#2)</html:p>
                     </html:section>
                 </html:body>
             </x:expect>
@@ -1564,7 +1582,7 @@
                 </html:body>
             </x:expect>
         </x:scenario>
-        <x:scenario label="where the doctitle is not a direct child of frontmatter">
+        <x:scenario label="where the doctitle for some reason is not a direct child of frontmatter">
             <x:context>
                 <dtbook:book>
                     <dtbook:frontmatter>

--- a/src/test/xspec/epub3-to-dtbook.xspec
+++ b/src/test/xspec/epub3-to-dtbook.xspec
@@ -592,12 +592,28 @@
     <!-- title -->
     <x:scenario label="when processing an element with a title class">
         <x:context>
-            <html:strong class="title"/>
-            <html:h3 class="title"/>
+            <html:section>
+                <html:strong class="title"/>
+                <html:h1 class="title"/>
+                <html:section epub:type="z3998:poem">
+                    <html:p class="title"/>
+                </html:section>
+                <html:section epub:type="z3998:verse">
+                    <html:p class="title"/>
+                </html:section>
+            </html:section>
         </x:context>
-        <x:expect label="the resulting element should be a title with the title class removed">
-            <dtbook:title/>
-            <dtbook:title/>
+        <x:expect label="the resulting element should be a title with the title class removed if it's in a poem; otherwise treat as if the title class was not there">
+            <dtbook:level1>
+                <dtbook:strong class="title"/>
+                <dtbook:h1 class="title"/>
+                <dtbook:poem>
+                    <dtbook:title/>
+                </dtbook:poem>
+                <dtbook:poem>
+                    <dtbook:title/>
+                </dtbook:poem>
+            </dtbook:level1>
         </x:expect>
     </x:scenario>
 
@@ -609,12 +625,21 @@
         <x:context>
             <html:body>
                 <html:header>
-                    <html:h1 epub:type="fulltitle">Document Title</html:h1>
-                    <html:p epub:type="z3998:author">Document Author</html:p>
+                    <html:h1 epub:type="fulltitle" class="title">Document Title</html:h1>
+                    <html:p epub:type="z3998:author" class="docauthor">Document Author</html:p>
                 </html:header>
                 <html:section>
                     <html:h1>Chapter Title</html:h1>
-                    <html:p epub:type="z3998:author">Author</html:p>
+                    <html:section epub:type="z3998:verse">
+                        <html:p epub:type="z3998:author">Author in poem context (2015-1)</html:p>
+                        <html:div class="linegroup"/>
+                    </html:section>
+                    <html:section epub:type="z3998:poem">
+                        <html:p epub:type="z3998:author">Author in poem context (2015-2)</html:p>
+                        <html:div epub:type="z3998:verse" class="linegroup"/>
+                    </html:section>
+                    <html:p epub:type="z3998:author">Author on p element</html:p>
+                    <html:p><html:span epub:type="z3998:author">Author on span element</html:span></html:p>
                 </html:section>
             </html:body>
         </x:context>
@@ -627,7 +652,16 @@
                 <dtbook:bodymatter>
                     <dtbook:level1>
                         <dtbook:h1>Chapter Title</dtbook:h1>
-                        <dtbook:author>Author</dtbook:author>
+                        <dtbook:poem>
+                            <dtbook:author>Author in poem context (2015-1)</dtbook:author>
+                            <dtbook:linegroup/>
+                        </dtbook:poem>
+                        <dtbook:poem>
+                            <dtbook:author>Author in poem context (2015-2)</dtbook:author>
+                            <dtbook:linegroup class="verse"/>
+                        </dtbook:poem>
+                        <dtbook:p>Author on p element</dtbook:p>
+                        <dtbook:p><dtbook:span class="author">Author on span element</dtbook:span></dtbook:p>
                     </dtbook:level1>
                 </dtbook:bodymatter>
             </dtbook:book>
@@ -1433,7 +1467,7 @@
                 <dtbook:book>
                     <dtbook:frontmatter>
                         <dtbook:level1 class="titlepage">
-                            <dtbook:author>AUTHOR</dtbook:author>
+                            <dtbook:p>AUTHOR</dtbook:p>
                         </dtbook:level1>
                     </dtbook:frontmatter>
                 </dtbook:book>
@@ -1443,7 +1477,7 @@
             <x:context>
                 <html:body>
                     <html:header>
-                        <html:p epub:type="z3998:author">DOCAUTHOR</html:p>
+                        <html:p epub:type="z3998:author" class="docauthor">DOCAUTHOR</html:p>
                     </html:header>
                 </html:body>
             </x:context>


### PR DESCRIPTION
doctitle and docauthor was already created in DTBook based on the OPF metadata from EPUB. However, there were inconsistencies to this rule, which should now be fixed.
# epub validation
- allow content in titlepage, fixes #191
  - titlepage is validated like any other frontmatter, except that its h1 needs to have epub:type="fulltitle" and class="title". The conversion logic does not need these attributes anymore, but it's required by the guidelines, and it makes for good semantic markup and easy css styling anyway. added these rules to check that markup is according to guidelines:
    - `[nordic263] the titlepage must have a headline (and the headline must have epub:type="fulltitle" and class="title")`
    - `[nordic264] the headline on the titlepage must have a epub:type with the value "fulltitle"`
    - `[nordic264] the headline on the titlepage must have a class with the value "title"`
- allow the use of epub:type="fulltitle" anywhere in content
- allow the use of epub:type="z3998:author" everywhere where the `<author>` element would be allowed in DTBook. These rules are removed:
  - `[tpb135b] z3998:author is only allowed either in the titlepage or inside a poem`
  - `[nordic262] Only <h1 epub:type="fulltitle" class="title"> and <p epub:type="z3998:author" class="docauthor"> are allowed on the titlepage.`
- renamed tpb135a into nordic135 and updated it to work with the way poems are marked up in guidelines revision 2015-1
# dtbook-to-epub3
- made sure jacketcopy and endnote is properly mapped to cover and rearnote even when not running in legacy mode
- convert `<author>` inside `<level1 class="titlepage">` into `<p epub:type="z3998:author" class="docauthor">` (won't ever happen though; `<author>` is not allowed in this context)
- convert `<h1>` inside `<level1 class="titlepage">` into `<h1 epub:type="fulltitle" class="title">`
- added/updated XSLT unit tests for the changes
# epub3-to-dtbook
- fixed mapping of poem title
- fixed mapping of poem author
- fixed mapping of poem
- added/updated XSLT unit tests for the changes
