### PR TITLE
added support for DTBook 1.1.0 when converting from nordic epub to dtboo...

### DIFF
--- a/src/main/resources/xml/xproc/epub3-to-dtbook.xpl
+++ b/src/main/resources/xml/xproc/epub3-to-dtbook.xpl
@@ -59,6 +59,14 @@
         </p:documentation>
     </p:option>
 
+    <!-- option supporting convert to DTBook 1.1.0 -->
+    <p:option name="dtbook2005" required="true" px:type="boolean">
+        <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+            <h2 px:role="name">DTBook 2005</h2>
+            <p px:role="desc">Whether or not to convert the output to DTBook 2005. Set to false to convert to DTBook 1.1.0</p>
+        </p:documentation>
+    </p:option>
+
     <p:import href="step/epub3.validate.xpl"/>
     <p:import href="step/html.validate.xpl"/>
     <p:import href="step/dtbook.validate.xpl"/>
@@ -242,6 +250,8 @@
                         <p:input port="in-memory.in">
                             <p:pipe port="in-memory.out" step="convert.html"/>
                         </p:input>
+                        <!-- call with dtbook2005 option whether to convert to a DTBook 2005 or DTBook 1.1.0 -->
+                        <p:with-option name="dtbook2005" select="$dtbook2005"/>
                     </px:nordic-html-to-dtbook-convert>
 
                     <px:fileset-move name="move">
@@ -264,6 +274,8 @@
                         <p:with-option name="dtbook" select="(/*/d:file[@media-type='application/x-dtbook+xml'])[1]/resolve-uri(@href,base-uri(.))">
                             <p:pipe port="fileset.out" step="fileset-store"/>
                         </p:with-option>
+                        <!-- call with dtbook2005 option whether to validate a DTBook 2005 or DTBook 1.1.0 -->
+                        <p:with-option name="dtbook2005" select="$dtbook2005"/>
                     </px:nordic-dtbook-validate.step>
                     <p:sink/>
 

--- a/src/main/resources/xml/xproc/epub3-to-dtbook.xpl
+++ b/src/main/resources/xml/xproc/epub3-to-dtbook.xpl
@@ -60,10 +60,10 @@
     </p:option>
 
     <!-- option supporting convert to DTBook 1.1.0 -->
-    <p:option name="dtbook2005" required="true" px:type="boolean">
+    <p:option name="dtbook2005" required="false" select="'true'" px:type="boolean">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
             <h2 px:role="name">DTBook 2005</h2>
-            <p px:role="desc">Whether or not to convert the output to DTBook 2005. Set to false to convert to DTBook 1.1.0</p>
+            <p px:role="desc">Whether or not to keep the DTBook 2005-3 output or downgrade to DTBook 1.1.0. Set to false to convert to DTBook 1.1.0.</p>
         </p:documentation>
     </p:option>
 

--- a/src/main/resources/xml/xproc/step/dtbook.validate.xpl
+++ b/src/main/resources/xml/xproc/step/dtbook.validate.xpl
@@ -23,7 +23,7 @@
     <p:option name="dtbook" required="true"/>
     <p:option name="check-images" required="false" select="'false'"/>
     <p:option name="allow-legacy" required="false" select="'false'"/>
-    
+
     <!-- option supporting convert to DTBook 1.1.0 -->
     <p:option name="dtbook2005" required="false" select="'true'"/>
 
@@ -69,40 +69,6 @@
             </pxi:fileset-add-entry>
             <p:identity name="invalid-fileset"/>
         </p:when>
-        <p:when test="$dtbook2005='false'">
-            <!-- validate document as DTBook 1.1.0 -->
-            <p:output port="report" sequence="true">
-                <p:pipe port="report" step="validate.input-dtbook.generic"/>
-            </p:output>
-            <p:output port="in-memory" sequence="true">
-                <p:pipe port="in-memory.out" step="input-dtbook.in-memory"/>
-            </p:output>
-            <p:output port="fileset">
-                <p:pipe port="result" step="input-dtbook.fileset"/>
-            </p:output>
-
-            <p:load>
-                <p:with-option name="href" select="$dtbook"/>
-            </p:load>
-
-            <p:identity name="input-dtbook"/>
-
-            <px:dtbook-load name="input-dtbook.in-memory">
-                <p:input port="source">
-                    <p:pipe port="result" step="input-dtbook"/>
-                </p:input>
-            </px:dtbook-load>
-            <p:viewport match="/*/*">
-                <px:message message="setting original-href for $1 to $2">
-                    <p:with-option name="param1" select="/*/@href"/>
-                    <p:with-option name="param2" select="if (/*/@original-href) then /*/@original-href else resolve-uri(/*/@href, base-uri(/*))"/>
-                </px:message>
-                <p:add-attribute match="/*" attribute-name="original-href">
-                    <p:with-option name="attribute-value" select="if (/*/@original-href) then /*/@original-href else resolve-uri(/*/@href, base-uri(/*))"/>
-                </p:add-attribute>
-            </p:viewport>
-            <px:mediatype-detect name="input-dtbook.fileset"/>
-        </p:when>
         <p:otherwise>
             <p:output port="report" sequence="true">
                 <p:pipe port="report" step="validate.input-dtbook.generic"/>
@@ -118,8 +84,9 @@
             <p:load>
                 <p:with-option name="href" select="$dtbook"/>
             </p:load>
+
             <p:choose>
-                <p:when test="$allow-legacy='true'">
+                <p:when test="$allow-legacy='true' and $dtbook2005='true'">
                     <px:upgrade-dtbook>
                         <p:input port="parameters">
                             <p:empty/>
@@ -138,51 +105,69 @@
                     <p:identity/>
                 </p:otherwise>
             </p:choose>
+
             <p:identity name="input-dtbook"/>
 
-            <px:message message="Validating DTBook according to Nordic specification..."/>
-            <l:relax-ng-report name="validate.input-dtbook.nordic.validation">
-                <p:input port="schema">
-                    <p:document href="../../schema/nordic-dtbook-2005-3.rng"/>
-                </p:input>
-                <p:with-option name="dtd-attribute-values" select="'false'"/>
-                <p:with-option name="dtd-id-idref-warnings" select="'false'"/>
-            </l:relax-ng-report>
-            <p:sink/>
+            <p:choose name="validate.input-dtbook.nordic">
+                <p:when test="$dtbook2005='true'">
+                    <p:output port="result" sequence="true"/>
 
-            <p:validate-with-schematron name="validate.input-dtbook.tpb.validation" assert-valid="false">
-                <p:input port="parameters">
-                    <p:empty/>
-                </p:input>
-                <p:input port="source">
-                    <p:pipe step="input-dtbook" port="result"/>
-                </p:input>
-                <p:input port="schema">
-                    <p:document href="../../schema/mtm2015-1.sch"/>
-                </p:input>
-            </p:validate-with-schematron>
-            <p:sink/>
+                    <px:message message="Validating DTBook according to Nordic specification..."/>
+                    <l:relax-ng-report name="validate.input-dtbook.nordic.validation">
+                        <p:input port="schema">
+                            <p:document href="../../schema/nordic-dtbook-2005-3.rng"/>
+                        </p:input>
+                        <p:with-option name="dtd-attribute-values" select="'false'"/>
+                        <p:with-option name="dtd-id-idref-warnings" select="'false'"/>
+                    </l:relax-ng-report>
+                    <p:sink/>
 
-            <px:combine-validation-reports name="validate.input-dtbook.nordic">
-                <p:input port="source">
-                    <p:pipe port="report" step="validate.input-dtbook.nordic.validation"/>
-                    <p:pipe port="report" step="validate.input-dtbook.tpb.validation"/>
-                    <p:inline>
-                        <c:errors>
-                            <!-- Temporary fix for v1.7. Will probably be fixed in v1.8. See: https://github.com/daisy-consortium/pipeline-modules-common/pull/48 -->
-                        </c:errors>
-                    </p:inline>
-                </p:input>
-                <p:with-option name="document-name" select="replace($dtbook,'.*/','')">
-                    <p:empty/>
-                </p:with-option>
-                <p:with-option name="document-type" select="'Nordic DTBook'">
-                    <p:empty/>
-                </p:with-option>
-                <p:with-option name="document-path" select="$dtbook">
-                    <p:empty/>
-                </p:with-option>
-            </px:combine-validation-reports>
+                    <p:validate-with-schematron name="validate.input-dtbook.tpb.validation" assert-valid="false">
+                        <p:input port="parameters">
+                            <p:empty/>
+                        </p:input>
+                        <p:input port="source">
+                            <p:pipe step="input-dtbook" port="result"/>
+                        </p:input>
+                        <p:input port="schema">
+                            <p:document href="../../schema/mtm2015-1.sch"/>
+                        </p:input>
+                    </p:validate-with-schematron>
+                    <p:sink/>
+
+                    <px:combine-validation-reports>
+                        <p:input port="source">
+                            <p:pipe port="report" step="validate.input-dtbook.nordic.validation"/>
+                            <p:pipe port="report" step="validate.input-dtbook.tpb.validation"/>
+                            <p:inline>
+                                <c:errors>
+                                    <!-- Temporary fix for v1.7. Will probably be fixed in v1.8. See: https://github.com/daisy-consortium/pipeline-modules-common/pull/48 -->
+                                </c:errors>
+                            </p:inline>
+                        </p:input>
+                        <p:with-option name="document-name" select="replace($dtbook,'.*/','')">
+                            <p:empty/>
+                        </p:with-option>
+                        <p:with-option name="document-type" select="'Nordic DTBook'">
+                            <p:empty/>
+                        </p:with-option>
+                        <p:with-option name="document-path" select="$dtbook">
+                            <p:empty/>
+                        </p:with-option>
+                    </px:combine-validation-reports>
+
+                </p:when>
+                <p:otherwise>
+                    <p:output port="result" sequence="true"/>
+
+                    <!-- DTBook 1.1.0 => no validation -->
+                    <p:identity>
+                        <p:input port="source">
+                            <p:empty/>
+                        </p:input>
+                    </p:identity>
+                </p:otherwise>
+            </p:choose>
 
             <px:dtbook-load name="input-dtbook.in-memory">
                 <p:input port="source">

--- a/src/main/resources/xml/xproc/step/dtbook.validate.xpl
+++ b/src/main/resources/xml/xproc/step/dtbook.validate.xpl
@@ -23,6 +23,9 @@
     <p:option name="dtbook" required="true"/>
     <p:option name="check-images" required="false" select="'false'"/>
     <p:option name="allow-legacy" required="false" select="'false'"/>
+    
+    <!-- option supporting convert to DTBook 1.1.0 -->
+    <p:option name="dtbook2005" required="false" select="'true'"/>
 
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
     <p:import href="../upstream/fileset-utils/fileset-load.xpl"/>
@@ -66,7 +69,40 @@
             </pxi:fileset-add-entry>
             <p:identity name="invalid-fileset"/>
         </p:when>
+        <p:when test="$dtbook2005='false'">
+            <!-- validate document as DTBook 1.1.0 -->
+            <p:output port="report" sequence="true">
+                <p:pipe port="report" step="validate.input-dtbook.generic"/>
+            </p:output>
+            <p:output port="in-memory" sequence="true">
+                <p:pipe port="in-memory.out" step="input-dtbook.in-memory"/>
+            </p:output>
+            <p:output port="fileset">
+                <p:pipe port="result" step="input-dtbook.fileset"/>
+            </p:output>
 
+            <p:load>
+                <p:with-option name="href" select="$dtbook"/>
+            </p:load>
+
+            <p:identity name="input-dtbook"/>
+
+            <px:dtbook-load name="input-dtbook.in-memory">
+                <p:input port="source">
+                    <p:pipe port="result" step="input-dtbook"/>
+                </p:input>
+            </px:dtbook-load>
+            <p:viewport match="/*/*">
+                <px:message message="setting original-href for $1 to $2">
+                    <p:with-option name="param1" select="/*/@href"/>
+                    <p:with-option name="param2" select="if (/*/@original-href) then /*/@original-href else resolve-uri(/*/@href, base-uri(/*))"/>
+                </px:message>
+                <p:add-attribute match="/*" attribute-name="original-href">
+                    <p:with-option name="attribute-value" select="if (/*/@original-href) then /*/@original-href else resolve-uri(/*/@href, base-uri(/*))"/>
+                </p:add-attribute>
+            </p:viewport>
+            <px:mediatype-detect name="input-dtbook.fileset"/>
+        </p:when>
         <p:otherwise>
             <p:output port="report" sequence="true">
                 <p:pipe port="report" step="validate.input-dtbook.generic"/>

--- a/src/main/resources/xml/xproc/step/epub3.validate.xpl
+++ b/src/main/resources/xml/xproc/step/epub3.validate.xpl
@@ -26,7 +26,7 @@
         <p:pipe port="result" step="epubcheck.validate"/>
         <p:pipe port="result" step="opf.validate"/>
         <p:pipe port="result" step="html.validate"/>
-        <p:pipe port="result" step="nav-references.validate"/>
+        <!--<p:pipe port="result" step="nav-references.validate"/>-->
         <p:pipe port="result" step="opf-and-html.validate"/>
         <p:pipe port="result" step="category.html-report"/>
     </p:output>
@@ -174,7 +174,7 @@
     <p:identity name="html"/>
     <p:sink/>
 
-    <px:fileset-filter media-types="application/xhtml+xml">
+    <!--<px:fileset-filter media-types="application/xhtml+xml">
         <p:input port="source">
             <p:pipe port="fileset" step="unzip"/>
         </p:input>
@@ -187,7 +187,7 @@
     </pxi:fileset-load>
     <px:assert test-count-min="1" test-count-max="1" message="There is no navigation document with the filename 'nav.xhtml' in the EPUB" error-code="NORDICDTBOOKEPUB013"/>
     <p:identity name="nav"/>
-    <p:sink/>
+    <p:sink/>-->
 
     <p:validate-with-schematron name="opf.validate.schematron" assert-valid="false">
         <p:input port="parameters">
@@ -436,7 +436,7 @@
     <p:identity name="opf-and-html.validate"/>
     <p:sink/>
 
-    <p:group>
+    <!--<p:group>
         <p:for-each>
             <p:iteration-source>
                 <p:pipe step="html" port="result"/>
@@ -489,7 +489,7 @@
         </px:combine-validation-reports>
     </p:group>
     <p:identity name="nav-references.validate"/>
-    <p:sink/>
+    <p:sink/>-->
 
     <px:fileset-filter media-types="application/xhtml+xml">
         <p:input port="source">

--- a/src/main/resources/xml/xproc/step/epub3.validate.xpl
+++ b/src/main/resources/xml/xproc/step/epub3.validate.xpl
@@ -26,7 +26,7 @@
         <p:pipe port="result" step="epubcheck.validate"/>
         <p:pipe port="result" step="opf.validate"/>
         <p:pipe port="result" step="html.validate"/>
-        <!--<p:pipe port="result" step="nav-references.validate"/>-->
+        <p:pipe port="result" step="nav-references.validate"/>
         <p:pipe port="result" step="opf-and-html.validate"/>
         <p:pipe port="result" step="category.html-report"/>
     </p:output>
@@ -174,7 +174,7 @@
     <p:identity name="html"/>
     <p:sink/>
 
-    <!--<px:fileset-filter media-types="application/xhtml+xml">
+    <px:fileset-filter media-types="application/xhtml+xml">
         <p:input port="source">
             <p:pipe port="fileset" step="unzip"/>
         </p:input>
@@ -187,7 +187,7 @@
     </pxi:fileset-load>
     <px:assert test-count-min="1" test-count-max="1" message="There is no navigation document with the filename 'nav.xhtml' in the EPUB" error-code="NORDICDTBOOKEPUB013"/>
     <p:identity name="nav"/>
-    <p:sink/>-->
+    <p:sink/>
 
     <p:validate-with-schematron name="opf.validate.schematron" assert-valid="false">
         <p:input port="parameters">
@@ -436,7 +436,7 @@
     <p:identity name="opf-and-html.validate"/>
     <p:sink/>
 
-    <!--<p:group>
+    <p:group>
         <p:for-each>
             <p:iteration-source>
                 <p:pipe step="html" port="result"/>
@@ -489,7 +489,7 @@
         </px:combine-validation-reports>
     </p:group>
     <p:identity name="nav-references.validate"/>
-    <p:sink/>-->
+    <p:sink/>
 
     <px:fileset-filter media-types="application/xhtml+xml">
         <p:input port="source">

--- a/src/main/resources/xml/xproc/step/html-to-dtbook.convert.xpl
+++ b/src/main/resources/xml/xproc/step/html-to-dtbook.convert.xpl
@@ -12,6 +12,9 @@
     <p:output port="in-memory.out" sequence="true">
         <p:pipe port="result" step="result.in-memory"/>
     </p:output>
+    
+    <!-- option supporting convert to DTBook 1.1.0 -->
+    <p:option name="dtbook2005" required="false" select="'true'"/>
 
     <p:import href="../upstream/fileset-utils/fileset-load.xpl"/>
     <p:import href="../upstream/fileset-utils/fileset-add-entry.xpl"/>
@@ -42,14 +45,39 @@
         </p:input>
     </p:xslt>
 
-    <p:xslt>
-        <p:input port="parameters">
-            <p:empty/>
-        </p:input>
-        <p:input port="stylesheet">
-            <p:document href="../../xslt/epub3-to-dtbook.xsl"/>
-        </p:input>
-    </p:xslt>
+    <p:choose>
+        <p:when test="$dtbook2005='true'">
+            <!-- convert to DTBook 2005 -->
+            <p:xslt>
+                <p:input port="parameters">
+                    <p:empty/>
+                </p:input>
+                <p:input port="stylesheet">
+                    <p:document href="../../xslt/epub3-to-dtbook.xsl"/>
+                </p:input>
+            </p:xslt>
+        </p:when>
+        <p:otherwise>
+            <!-- convert to DTBook 2005 -->
+            <p:xslt>
+                <p:input port="parameters">
+                    <p:empty/>
+                </p:input>
+                <p:input port="stylesheet">
+                    <p:document href="../../xslt/epub3-to-dtbook.xsl"/>
+                </p:input>
+            </p:xslt>
+            <!-- then convert to DTBook 1.1.0 -->
+            <p:xslt>
+                <p:input port="parameters">
+                    <p:empty/>
+                </p:input>
+                <p:input port="stylesheet">
+                    <p:document href="../../xslt/dtbook2005-to-dtbook110.xsl"/>
+                </p:input>
+            </p:xslt>
+        </p:otherwise>
+    </p:choose>
 
     <p:add-attribute match="/*" attribute-name="xml:base">
         <p:with-option name="attribute-value" select="concat(replace(base-uri(/*),'^(.*)\.[^/\.]*$','$1'),'.xml')">
@@ -82,11 +110,20 @@
             <p:with-option name="attribute-value" select="replace(/*/@href,'^images/','')"/>
         </p:add-attribute>
     </p:viewport>
-    <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="doctype-public" attribute-value="-//NISO//DTD dtbook 2005-3//EN"/>
-    <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="doctype-system" attribute-value="http://www.daisy.org/z3986/2005/dtbook-2005-3.dtd"/>
     <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="omit-xml-declaration" attribute-value="false"/>
     <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="version" attribute-value="1.0"/>
     <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="encoding" attribute-value="utf-8"/>
+    <p:choose>
+        <p:when test="$dtbook2005='true'">
+            <!-- add doctype attributes to DTBook 2005 -->
+            <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="doctype-public" attribute-value="-//NISO//DTD dtbook 2005-3//EN"/>
+            <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="doctype-system" attribute-value="http://www.daisy.org/z3986/2005/dtbook-2005-3.dtd"/>
+        </p:when>
+        <p:otherwise>
+            <!-- add standalone 'yes' to DTBook 1.1.0 -->
+            <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="standalone" attribute-value="true"/>
+        </p:otherwise>
+    </p:choose>
     <p:xslt>
         <p:with-param name="preserve-empty-whitespace" select="'false'"/>
         <p:input port="stylesheet">

--- a/src/main/resources/xml/xproc/step/html-to-dtbook.convert.xpl
+++ b/src/main/resources/xml/xproc/step/html-to-dtbook.convert.xpl
@@ -44,30 +44,22 @@
             <p:document href="../../xslt/deep-level-grouping.xsl"/>
         </p:input>
     </p:xslt>
-
+    
+    <p:xslt>
+        <p:input port="parameters">
+            <p:empty/>
+        </p:input>
+        <p:input port="stylesheet">
+            <p:document href="../../xslt/epub3-to-dtbook.xsl"/>
+        </p:input>
+    </p:xslt>
     <p:choose>
         <p:when test="$dtbook2005='true'">
-            <!-- convert to DTBook 2005 -->
-            <p:xslt>
-                <p:input port="parameters">
-                    <p:empty/>
-                </p:input>
-                <p:input port="stylesheet">
-                    <p:document href="../../xslt/epub3-to-dtbook.xsl"/>
-                </p:input>
-            </p:xslt>
+            <!-- keep DTBook 2005-3 -->
+            <p:identity/>
         </p:when>
         <p:otherwise>
-            <!-- convert to DTBook 2005 -->
-            <p:xslt>
-                <p:input port="parameters">
-                    <p:empty/>
-                </p:input>
-                <p:input port="stylesheet">
-                    <p:document href="../../xslt/epub3-to-dtbook.xsl"/>
-                </p:input>
-            </p:xslt>
-            <!-- then convert to DTBook 1.1.0 -->
+            <!-- convert to DTBook 1.1.0 -->
             <p:xslt>
                 <p:input port="parameters">
                     <p:empty/>
@@ -115,7 +107,7 @@
     <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="encoding" attribute-value="utf-8"/>
     <p:choose>
         <p:when test="$dtbook2005='true'">
-            <!-- add doctype attributes to DTBook 2005 -->
+            <!-- add doctype attributes to DTBook 2005-3 -->
             <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="doctype-public" attribute-value="-//NISO//DTD dtbook 2005-3//EN"/>
             <p:add-attribute match="//d:file[@media-type='application/x-dtbook+xml']" attribute-name="doctype-system" attribute-value="http://www.daisy.org/z3986/2005/dtbook-2005-3.dtd"/>
         </p:when>

--- a/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
+++ b/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
@@ -2,11 +2,11 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:msxsl="urn:schemas-microsoft-com:xslt"
     xmlns:x="http://www.daisy.org/z3986/2005/dtbook/"
-    exclude-result-prefixes="x msxsl">
+    exclude-result-prefixes="x msxsl" >
   
-  <xsl:output method="xml" indent="yes" doctype-system="dtbook110.dtd"/>
+  <xsl:output method="xml" indent="yes" doctype-system="dtbook110.dtd" encoding="utf-8"/>
 
-  <!--Version 0.4 - 2014.12.04-->
+  <!--Version 0.5 - 2014.12.05-->
   
   <xsl:template match="/">
     <xsl:apply-templates/>
@@ -116,9 +116,17 @@
     <xsl:choose>
       <xsl:when test="parent::x:imggroup">
         <prodnote class="caption" render="required">
-          <p>
-            <xsl:apply-templates/>
-          </p>
+          <xsl:choose>
+            <xsl:when test="child::x:p|child::x:table|child::x:div">          
+                <xsl:apply-templates/>  
+            </xsl:when>
+            <xsl:otherwise>
+              <p>
+                <xsl:apply-templates/>
+              </p>         
+            </xsl:otherwise>
+          </xsl:choose>
+        
         </prodnote>
       </xsl:when>
       <xsl:otherwise>
@@ -514,6 +522,8 @@
   <!-- if pagenum is child of imggroup report-->
   <xsl:template match="x:pagenum">
     <xsl:choose>
+      
+      <!--Parent er imggroup: indsæt kommentar-->
       <xsl:when test ="parent::x:imggroup">
         <xsl:comment>
           <xsl:text>Konverteringsproblem: pagenum kan ikke befinde sig på denne position: </xsl:text>
@@ -525,6 +535,46 @@
           <xsl:text>&lt;/pagenum&gt;</xsl:text>
         </xsl:comment>
       </xsl:when>
+      
+      <!--Parent er table: Indsæt ny table-->
+      <xsl:when test ="parent::x:table">
+        <!-- Afslut den forrige-->
+        <xsl:text disable-output-escaping ="yes">&lt;/table&gt;</xsl:text>
+        
+        <!--Indsæt sidetallet-->
+        <pagenum>
+          <xsl:for-each select="@*">
+            <xsl:attribute name="{name()}">
+              <xsl:value-of select="."/>
+            </xsl:attribute>
+          </xsl:for-each>
+          <xsl:apply-templates/>
+        </pagenum>
+        
+        <!-- Begynd en ny tabel-->
+        <xsl:text disable-output-escaping ="yes">&lt;table&gt;</xsl:text>
+        
+      </xsl:when>
+      
+      <!--Parent er tbody: indsæt nyt table/tbody-->
+      <xsl:when test ="parent::x:tbody">
+        <!-- Afslut den forrige-->
+        <xsl:text disable-output-escaping ="yes">&lt;/tbody&gt;&lt;/table&gt;</xsl:text>
+
+        <!--Indsæt sidetallet-->
+        <pagenum>
+          <xsl:for-each select="@*">
+            <xsl:attribute name="{name()}">
+              <xsl:value-of select="."/>
+            </xsl:attribute>
+          </xsl:for-each>
+          <xsl:apply-templates/>
+        </pagenum>
+
+        <!-- Begynd en ny tabel-->
+        <xsl:text disable-output-escaping ="yes">&lt;table&gt;&lt;tbody&gt;</xsl:text>
+      </xsl:when>
+      
       <xsl:otherwise>
         <pagenum>
           <xsl:for-each select="@*">

--- a/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
+++ b/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
@@ -535,12 +535,11 @@
           <xsl:text>&lt;/pagenum&gt;</xsl:text>
         </xsl:comment>
       </xsl:when>
-      
-      <!--Parent er table: Indsæt ny table-->
-      <xsl:when test ="parent::x:table">
+
+      <xsl:when test ="preceding-sibling::x:tr">
         <!-- Afslut den forrige-->
         <xsl:text disable-output-escaping ="yes">&lt;/table&gt;</xsl:text>
-        
+
         <!--Indsæt sidetallet-->
         <pagenum>
           <xsl:for-each select="@*">
@@ -550,9 +549,22 @@
           </xsl:for-each>
           <xsl:apply-templates/>
         </pagenum>
-        
+
         <!-- Begynd en ny tabel-->
         <xsl:text disable-output-escaping ="yes">&lt;table&gt;</xsl:text>
+      </xsl:when>
+      
+      <!--Parent er table: Indsæt ny table-->
+      <xsl:when test ="parent::x:table">
+        <xsl:comment>
+          <xsl:text>Konverteringsproblem: pagenum kan ikke befinde sig på denne position: </xsl:text>
+          <xsl:text>&lt;pagenum id='</xsl:text>
+          <xsl:value-of select="@id"/>
+          <xsl:text>'&gt;</xsl:text>
+          <xsl:variable name="nodeAsStr" select="string(.)" />
+          <xsl:copy-of select="$nodeAsStr"/>
+          <xsl:text>&lt;/pagenum&gt;</xsl:text>
+        </xsl:comment>
         
       </xsl:when>
       

--- a/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
+++ b/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
@@ -1,0 +1,750 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+    xmlns:x="http://www.daisy.org/z3986/2005/dtbook/"
+    exclude-result-prefixes="x msxsl">
+  
+  <xsl:output method="xml" indent="yes" doctype-system="dtbook110.dtd"/>
+
+  <!--Version 0.4 - 2014.12.04-->
+  
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="x:dtbook">
+    <dtbook version="1.1.0">
+      <xsl:apply-templates/>
+    </dtbook>
+  </xsl:template>
+  
+  <xsl:template match="x:a">
+    <a>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </a>
+  </xsl:template>
+
+  <xsl:template match="x:abbr">
+    <abbr>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </abbr>
+  </xsl:template>
+
+  <xsl:template match="x:acronym">
+    <acronym>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </acronym>
+  </xsl:template>
+
+  <xsl:template match="x:annoref">
+    <annoref>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </annoref>
+  </xsl:template>
+
+  <xsl:template match="x:blockqoute">
+    <div class="blockquote">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="x:book">
+    <book>
+      <xsl:if test="parent::x:dtbook/@xml:lang">
+        <xsl:attribute name="lang">
+          <xsl:value-of select="parent::x:dtbook/@xml:lang"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </book>
+  </xsl:template>
+
+  <xsl:template match="x:bodymatter">
+    <bodymatter>
+      <xsl:apply-templates/>
+    </bodymatter>
+  </xsl:template>
+
+  <xsl:template match="x:br">
+    <br>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </br>
+  </xsl:template>
+
+  <xsl:template match="x:bridgehead">
+    <p class="bridgehead">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="x:caption">
+    <xsl:choose>
+      <xsl:when test="parent::x:imggroup">
+        <prodnote class="caption" render="required">
+          <p>
+            <xsl:apply-templates/>
+          </p>
+        </prodnote>
+      </xsl:when>
+      <xsl:otherwise>
+        <caption>
+          <xsl:for-each select="@*">
+            <xsl:attribute name="{name()}">
+              <xsl:value-of select="."/>
+            </xsl:attribute>
+          </xsl:for-each>
+          <xsl:apply-templates/>
+        </caption>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="x:code">
+    <code>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </code>
+  </xsl:template>
+
+  <xsl:template match="x:colgroup">
+    <colgroup>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </colgroup>
+  </xsl:template>
+
+  <xsl:template match="x:dd">
+    <dd>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </dd>
+  </xsl:template>
+
+  <xsl:template match="x:dl">
+    <dl>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </dl>
+  </xsl:template>
+
+  <xsl:template match="x:docauthor">
+    <docauthor>
+      <xsl:apply-templates/>
+    </docauthor>
+  </xsl:template>
+
+  <xsl:template match="x:doctitle">
+    <doctitle>
+      <xsl:apply-templates/>
+    </doctitle>
+  </xsl:template>
+
+  <xsl:template match="x:dt">
+    <dt>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </dt>
+  </xsl:template>
+
+  <xsl:template match="x:em">
+    <em>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </em>
+  </xsl:template>
+
+  <xsl:template match="x:frontmatter">
+    <frontmatter>
+      <xsl:apply-templates/>
+    </frontmatter>
+  </xsl:template>
+
+  <xsl:template match="x:h1">
+    <levelhd depth="1">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </levelhd>
+  </xsl:template>
+
+  <xsl:template match="x:h2">
+    <levelhd depth="2">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </levelhd>
+  </xsl:template>
+
+  <xsl:template match="x:h3">
+    <levelhd depth="3">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </levelhd>
+  </xsl:template>
+
+  <xsl:template match="x:h4">
+    <levelhd depth="4">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </levelhd>
+  </xsl:template>
+
+  <xsl:template match="x:h5">
+    <levelhd depth="5">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </levelhd>
+  </xsl:template>
+
+  <xsl:template match="x:h6">
+    <levelhd depth="6">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </levelhd>
+  </xsl:template>
+
+  <xsl:template match="x:head">
+    <head>
+      <title>
+        <xsl:value-of select ="string(x:meta[@name='dc:Title']/@content)"/>
+      </title>
+      <xsl:apply-templates />
+    </head>
+  </xsl:template>
+
+  <xsl:template match="x:img">
+    <img>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </img>
+  </xsl:template>
+
+  <xsl:template match="x:imggroup">
+    <imggroup>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </imggroup>
+  </xsl:template>
+
+  <xsl:template match="x:kbd">
+    <kbd>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </kbd>
+  </xsl:template>
+
+  <xsl:template match="x:level1">
+    <level depth="1">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </level>
+  </xsl:template>
+
+  <xsl:template match="x:level6">
+    <level depth="6">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </level>
+  </xsl:template>
+
+  <xsl:template match="x:level2">
+    <level depth="2">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </level>
+  </xsl:template>
+
+  <xsl:template match="x:level5">
+    <level depth="5">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </level>
+  </xsl:template>
+
+  <xsl:template match="x:level3">
+    <level depth="3">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </level>
+  </xsl:template>
+
+  <xsl:template match="x:level4">
+    <level depth="4">
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </level>
+  </xsl:template>
+
+  <xsl:template match="x:li">
+    <li>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </li>
+  </xsl:template>
+
+  <xsl:template match="x:lic">
+    <lic>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </lic>
+  </xsl:template>
+  
+  <xsl:template match="x:list">
+    <xsl:choose>
+      <xsl:when test="string(@type)='pl'">
+        
+        <!--Check om første li har &#x25A0; eller &#x2022; som første karakter-->
+
+        <xsl:choose>
+          <xsl:when test="contains(string(child::x:li),'&#x25A0;')">
+            <list type="ul" bullet="none">
+              <xsl:apply-templates/>
+            </list>
+          </xsl:when>
+
+          <xsl:when test="contains(string(child::x:li),'&#x2022;')">
+            <list type="ul" bullet="none">
+              <xsl:apply-templates/>
+            </list>
+          </xsl:when>
+
+          <xsl:otherwise>
+            <list type="ul">
+              <xsl:apply-templates/>
+            </list>
+          </xsl:otherwise>
+        </xsl:choose>
+       
+      </xsl:when>
+      
+      <xsl:when test="string(@type)='ul'">
+        <list type="ul">
+          <xsl:apply-templates/>
+        </list>
+      </xsl:when>
+      <xsl:otherwise>
+        <list type="ol">
+          <xsl:apply-templates/>
+        </list>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="x:linegroup">
+    <div class="stanza">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="x:line">
+    <p class="line">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="x:meta">
+    <xsl:element name ="meta">
+      <xsl:attribute name="name">
+        <xsl:value-of select="string(@name)"/>
+      </xsl:attribute>
+      <xsl:attribute name="content">
+        <xsl:value-of select="string(@content)"/>
+      </xsl:attribute>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="x:noteref">
+    <noteref>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </noteref>
+  </xsl:template>
+
+  <xsl:template match="x:note">
+    <note>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </note>
+  </xsl:template>
+
+  <xsl:template match="x:p">
+    <p>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+  
+  <!-- if pagenum is child of imggroup report-->
+  <xsl:template match="x:pagenum">
+    <xsl:choose>
+      <xsl:when test ="parent::x:imggroup">
+        <xsl:comment>
+          <xsl:text>Konverteringsproblem: pagenum kan ikke befinde sig på denne position: </xsl:text>
+          <xsl:text>&lt;pagenum id='</xsl:text>
+          <xsl:value-of select="@id"/>
+          <xsl:text>'&gt;</xsl:text>
+          <xsl:variable name="nodeAsStr" select="string(.)" />
+          <xsl:copy-of select="$nodeAsStr"/>
+          <xsl:text>&lt;/pagenum&gt;</xsl:text>
+        </xsl:comment>
+      </xsl:when>
+      <xsl:otherwise>
+        <pagenum>
+          <xsl:for-each select="@*">
+            <xsl:attribute name="{name()}">
+              <xsl:value-of select="."/>
+            </xsl:attribute>
+          </xsl:for-each>
+          <xsl:apply-templates/>
+        </pagenum>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="x:poem">
+    <div class="poem">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="x:prodnote">
+    <prodnote>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </prodnote>
+  </xsl:template>
+
+  <xsl:template match="x:q">
+    <q>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </q>
+  </xsl:template>
+
+  <xsl:template match="x:rearmatter">
+    <rearmatter>
+      <xsl:apply-templates/>
+    </rearmatter>
+  </xsl:template>
+
+  <xsl:template match="x:samp">
+    <samp>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </samp>
+  </xsl:template>
+
+  <xsl:template match="x:sent">
+    <sent>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </sent>
+  </xsl:template>
+
+  <!--Attributten render er forbudt i 110-->
+  
+  <xsl:template match="x:sidebar">
+    <sidebar>
+
+      <xsl:if test ="@id">
+        <xsl:attribute name ="id">
+          <xsl:value-of select="@id"/>
+        </xsl:attribute>
+      </xsl:if>
+
+      <xsl:if test ="@class">
+        <xsl:attribute name ="class">
+          <xsl:value-of select="@class"/>
+        </xsl:attribute>
+      </xsl:if>      
+      
+      <xsl:apply-templates/>
+    </sidebar>
+  </xsl:template>
+  
+  <xsl:template match="x:span">
+    <span>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="x:strong">
+    <strong>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </strong>
+  </xsl:template>
+
+  <xsl:template match="x:sub">
+    <sub>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </sub>
+  </xsl:template>
+
+  <xsl:template match="x:sup">
+    <sup>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </sup>
+  </xsl:template>
+
+  <xsl:template match="x:table">
+    <table>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </table>
+  </xsl:template>
+
+  <xsl:template match="x:tbody">
+    <tbody>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </tbody>
+  </xsl:template>
+  
+  <xsl:template match="x:td">
+    <td>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </td>
+  </xsl:template>
+
+  <xsl:template match="x:tfoot">
+    <tfoot>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </tfoot>
+  </xsl:template>
+
+  <xsl:template match="x:th">
+    <th>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </th>
+  </xsl:template>
+
+  <xsl:template match="x:thead">
+    <thead>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </thead>
+  </xsl:template>
+
+  <xsl:template match="x:tr">
+    <tr>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="x:w">
+    <w>
+      <xsl:for-each select="@*">
+        <xsl:attribute name="{name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </w>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
+++ b/src/main/resources/xml/xslt/dtbook2005-to-dtbook110.xsl
@@ -1,13 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:msxsl="urn:schemas-microsoft-com:xslt"
-    xmlns:x="http://www.daisy.org/z3986/2005/dtbook/"
-    exclude-result-prefixes="x msxsl" >
-  
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:msxsl="urn:schemas-microsoft-com:xslt" xmlns:x="http://www.daisy.org/z3986/2005/dtbook/"
+  exclude-result-prefixes="x msxsl">
+
   <xsl:output method="xml" indent="yes" doctype-system="dtbook110.dtd" encoding="utf-8"/>
 
   <!--Version 0.5 - 2014.12.05-->
-  
+
   <xsl:template match="/">
     <xsl:apply-templates/>
   </xsl:template>
@@ -17,7 +15,7 @@
       <xsl:apply-templates/>
     </dtbook>
   </xsl:template>
-  
+
   <xsl:template match="x:a">
     <a>
       <xsl:for-each select="@*">
@@ -117,16 +115,16 @@
       <xsl:when test="parent::x:imggroup">
         <prodnote class="caption" render="required">
           <xsl:choose>
-            <xsl:when test="child::x:p|child::x:table|child::x:div">          
-                <xsl:apply-templates/>  
+            <xsl:when test="child::x:p|child::x:table|child::x:div">
+              <xsl:apply-templates/>
             </xsl:when>
             <xsl:otherwise>
               <p>
                 <xsl:apply-templates/>
-              </p>         
+              </p>
             </xsl:otherwise>
           </xsl:choose>
-        
+
         </prodnote>
       </xsl:when>
       <xsl:otherwise>
@@ -295,9 +293,9 @@
   <xsl:template match="x:head">
     <head>
       <title>
-        <xsl:value-of select ="string(x:meta[@name='dc:Title']/@content)"/>
+        <xsl:value-of select="string(x:meta[@name='dc:Title']/@content)"/>
       </title>
-      <xsl:apply-templates />
+      <xsl:apply-templates/>
     </head>
   </xsl:template>
 
@@ -421,11 +419,11 @@
       <xsl:apply-templates/>
     </lic>
   </xsl:template>
-  
+
   <xsl:template match="x:list">
     <xsl:choose>
       <xsl:when test="string(@type)='pl'">
-        
+
         <!--Check om første li har &#x25A0; eller &#x2022; som første karakter-->
 
         <xsl:choose>
@@ -447,9 +445,9 @@
             </list>
           </xsl:otherwise>
         </xsl:choose>
-       
+
       </xsl:when>
-      
+
       <xsl:when test="string(@type)='ul'">
         <list type="ul">
           <xsl:apply-templates/>
@@ -476,7 +474,7 @@
   </xsl:template>
 
   <xsl:template match="x:meta">
-    <xsl:element name ="meta">
+    <xsl:element name="meta">
       <xsl:attribute name="name">
         <xsl:value-of select="string(@name)"/>
       </xsl:attribute>
@@ -518,27 +516,27 @@
       <xsl:apply-templates/>
     </p>
   </xsl:template>
-  
+
   <!-- if pagenum is child of imggroup report-->
   <xsl:template match="x:pagenum">
     <xsl:choose>
-      
+
       <!--Parent er imggroup: indsæt kommentar-->
-      <xsl:when test ="parent::x:imggroup">
+      <xsl:when test="parent::x:imggroup">
         <xsl:comment>
           <xsl:text>Konverteringsproblem: pagenum kan ikke befinde sig på denne position: </xsl:text>
           <xsl:text>&lt;pagenum id='</xsl:text>
           <xsl:value-of select="@id"/>
           <xsl:text>'&gt;</xsl:text>
-          <xsl:variable name="nodeAsStr" select="string(.)" />
+          <xsl:variable name="nodeAsStr" select="string(.)"/>
           <xsl:copy-of select="$nodeAsStr"/>
           <xsl:text>&lt;/pagenum&gt;</xsl:text>
         </xsl:comment>
       </xsl:when>
 
-      <xsl:when test ="preceding-sibling::x:tr">
+      <xsl:when test="preceding-sibling::x:tr">
         <!-- Afslut den forrige-->
-        <xsl:text disable-output-escaping ="yes">&lt;/table&gt;</xsl:text>
+        <xsl:text disable-output-escaping="yes">&lt;/table&gt;</xsl:text>
 
         <!--Indsæt sidetallet-->
         <pagenum>
@@ -551,27 +549,27 @@
         </pagenum>
 
         <!-- Begynd en ny tabel-->
-        <xsl:text disable-output-escaping ="yes">&lt;table&gt;</xsl:text>
+        <xsl:text disable-output-escaping="yes">&lt;table&gt;</xsl:text>
       </xsl:when>
-      
+
       <!--Parent er table: Indsæt ny table-->
-      <xsl:when test ="parent::x:table">
+      <xsl:when test="parent::x:table">
         <xsl:comment>
           <xsl:text>Konverteringsproblem: pagenum kan ikke befinde sig på denne position: </xsl:text>
           <xsl:text>&lt;pagenum id='</xsl:text>
           <xsl:value-of select="@id"/>
           <xsl:text>'&gt;</xsl:text>
-          <xsl:variable name="nodeAsStr" select="string(.)" />
+          <xsl:variable name="nodeAsStr" select="string(.)"/>
           <xsl:copy-of select="$nodeAsStr"/>
           <xsl:text>&lt;/pagenum&gt;</xsl:text>
         </xsl:comment>
-        
+
       </xsl:when>
-      
+
       <!--Parent er tbody: indsæt nyt table/tbody-->
-      <xsl:when test ="parent::x:tbody">
+      <xsl:when test="parent::x:tbody">
         <!-- Afslut den forrige-->
-        <xsl:text disable-output-escaping ="yes">&lt;/tbody&gt;&lt;/table&gt;</xsl:text>
+        <xsl:text disable-output-escaping="yes">&lt;/tbody&gt;&lt;/table&gt;</xsl:text>
 
         <!--Indsæt sidetallet-->
         <pagenum>
@@ -584,9 +582,9 @@
         </pagenum>
 
         <!-- Begynd en ny tabel-->
-        <xsl:text disable-output-escaping ="yes">&lt;table&gt;&lt;tbody&gt;</xsl:text>
+        <xsl:text disable-output-escaping="yes">&lt;table&gt;&lt;tbody&gt;</xsl:text>
       </xsl:when>
-      
+
       <xsl:otherwise>
         <pagenum>
           <xsl:for-each select="@*">
@@ -657,26 +655,26 @@
   </xsl:template>
 
   <!--Attributten render er forbudt i 110-->
-  
+
   <xsl:template match="x:sidebar">
     <sidebar>
 
-      <xsl:if test ="@id">
-        <xsl:attribute name ="id">
+      <xsl:if test="@id">
+        <xsl:attribute name="id">
           <xsl:value-of select="@id"/>
         </xsl:attribute>
       </xsl:if>
 
-      <xsl:if test ="@class">
-        <xsl:attribute name ="class">
+      <xsl:if test="@class">
+        <xsl:attribute name="class">
           <xsl:value-of select="@class"/>
         </xsl:attribute>
-      </xsl:if>      
-      
+      </xsl:if>
+
       <xsl:apply-templates/>
     </sidebar>
   </xsl:template>
-  
+
   <xsl:template match="x:span">
     <span>
       <xsl:for-each select="@*">
@@ -742,7 +740,7 @@
       <xsl:apply-templates/>
     </tbody>
   </xsl:template>
-  
+
   <xsl:template match="x:td">
     <td>
       <xsl:for-each select="@*">


### PR DESCRIPTION
We have inserted an option in the step Nordic EPUB3 to DTBook to convert to DTBook 1.1.0 (used by Nota) which is set to true as default (default is DTBook 2005). The actual conversion is executed by a stylesheet from DTBook 2005 to DTBook 1.1.0.
These changes only works when pull from jostein daisy/pipeline-scripts#63 is merged into dtbook-validator.

<!---
@huboard:{"custom_state":"","order":240.0,"milestone_order":240}
-->
