### PR TITLE
use hd in sidebars and poems. wrap inline note content in paragraphs.

### DIFF
--- a/src/main/resources/xml/schema/nordic2015-1.sch
+++ b/src/main/resources/xml/schema/nordic2015-1.sch
@@ -852,4 +852,25 @@
         </rule>
     </pattern>
 
+    <!-- Rule 268: Check that the heading levels are nested correctly (necessary for sidebars and poems, and maybe other structures as well where the RelaxNG is unable to enforce the level) -->
+    <pattern id="epub_nordic_268">
+        <rule context="html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6">
+            <let name="sectioning-element" value="ancestor::*[self::html:section or self::html:article or self::html:aside or self::html:nav or self::html:body][1]"/>
+            <let name="this-level" value="xs:integer(replace(name(),'.*(\d)$','$1')) + (if (ancestor::html:header[parent::html:body]) then -1 else 0)"/>
+            <let name="child-sectioning-elements"
+                value="$sectioning-element//*[self::html:section or self::html:article or self::html:aside or self::html:nav or self::html:figure][ancestor::*[self::html:section or self::html:article or self::html:aside or self::html:nav or self::html:body][1] intersect $sectioning-element]"/>
+            <let name="child-sectioning-element-with-wrong-level"
+                value="$child-sectioning-elements[count(html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6) != 0 and (html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6)/xs:integer(replace(name(),'.*(\d)$','$1')) != min((6, $this-level + 1))][1]"/>
+            <assert test="count($child-sectioning-element-with-wrong-level) = 0">[nordic268] The subsections of <value-of
+                    select="concat('&lt;',$sectioning-element/name(),string-join(for $a in ($sectioning-element/@*) return concat(' ',$a/name(),'=&quot;',$a,'&quot;'),''),'&gt;')"/> (which contains
+                the headline <value-of select="concat('&lt;',name(),string-join(for $a in (@*) return concat(' ',$a/name(),'=&quot;',$a,'&quot;'),''),'&gt;')"/><value-of
+                    select="string-join(.//text(),' ')"/>&lt;/<name/>&gt;) must only use &lt;h<value-of select="min((6, $this-level + 1))"/>&gt; for headlines. It contains the element <value-of
+                    select="concat('&lt;',$child-sectioning-element-with-wrong-level/name(),string-join(for $a in ($child-sectioning-element-with-wrong-level/@*) return concat(' ',$a/name(),'=&quot;',$a,'&quot;'),''),'&gt;')"
+                /> which contains the headline <value-of
+                    select="concat('&lt;',$child-sectioning-element-with-wrong-level/(html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6)[1]/name(),string-join(for $a in ($child-sectioning-element-with-wrong-level/(html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6)[1]/@*) return concat(' ',$a/name(),'=&quot;',$a,'&quot;'),''),'&gt;',string-join($child-sectioning-element-with-wrong-level/(html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6)[1]//text(),' '),'&lt;/',$child-sectioning-element-with-wrong-level/(html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6)[1]/name(),'&gt;')"
+                />
+            </assert>
+        </rule>
+    </pattern>
+
 </schema>

--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -1723,7 +1723,7 @@
         <xsl:param name="element" as="element()"/>
         <xsl:variable name="level"
             select="count($element/ancestor-or-self::*[self::dtbook:level or self::dtbook:level1 or self::dtbook:level2 or self::dtbook:level3 or self::dtbook:level4 or self::dtbook:level5 or self::dtbook:level6 or self::dtbook:linegroup[dtbook:hd] or self::dtbook:poem[dtbook:hd]])"/>
-        <xsl:sequence select="min(($level, 6))"/>
+        <xsl:sequence select="max((1, min(($level, 6))))"/>
     </xsl:function>
 
     <xsl:function name="f:generate-pretty-id" as="xs:string">

--- a/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
+++ b/src/main/resources/xml/xslt/epub3-to-dtbook.xsl
@@ -23,7 +23,7 @@
     </xsl:template>
 
     <xsl:template match="*">
-        <xsl:comment select="concat('No template for element: ',name())"/>
+        <xsl:comment select="concat('No template for element: &lt;',name(),string-join(for $a in (@*) return concat(' ',$a/name(),'=&quot;',$a,'&quot;'),''),'&gt;')"/>
     </xsl:template>
 
     <xsl:template match="html:style"/>
@@ -414,7 +414,16 @@
     <xsl:template match="html:aside[f:types(.)='note'] | html:li[f:types(.)=('rearnote','footnote')]">
         <note>
             <xsl:call-template name="attlist.note"/>
-            <xsl:apply-templates select="node()"/>
+            <xsl:choose>
+                <xsl:when test="(text()[normalize-space()] | *)/f:is-inline(.) = true()">
+                    <p>
+                        <xsl:apply-templates select="node()"/>
+                    </p>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="node()"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </note>
     </xsl:template>
 
@@ -1007,7 +1016,7 @@
     </xsl:template>
 
     <xsl:template match="html:h1 | html:h2 | html:h3 | html:h4 | html:h5 | html:h6">
-        <xsl:element name="h{f:level(.)}">
+        <xsl:element name="h{if (parent::*/f:types(.)=('sidebar','z3998:poem','z3998:verse') or parent::*/f:classes(.)='linegroup') then 'd' else f:level(.)}">
             <xsl:call-template name="attlist.h"/>
             <xsl:apply-templates select="node()"/>
         </xsl:element>

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -755,6 +755,18 @@
                 <html:figure id="..." epub:type="sidebar" class="sidebar"/>
             </x:expect>
         </x:scenario>
+        <x:scenario label="with a hd element">
+            <x:context>
+                <dtbook:sidebar>
+                    <dtbook:hd>Headline</dtbook:hd>
+                </dtbook:sidebar>
+            </x:context>
+            <x:expect label="the hd element should become a headline">
+                <html:aside id="..." epub:type="sidebar" class="sidebar">
+                    <html:h1 id="...">Headline</html:h1>
+                </html:aside>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
 
     <!-- attlist.sidebar -->

--- a/src/test/xspec/epub3-to-dtbook.xspec
+++ b/src/test/xspec/epub3-to-dtbook.xspec
@@ -717,6 +717,28 @@
                 <dtbook:sidebar render="required"/>
             </x:expect>
         </x:scenario>
+        <x:scenario label="and the element contains a headline">
+            <x:context>
+                <html:section>
+                    <html:aside epub:type="sidebar">
+                        <html:h1>Sidebar 1</html:h1>
+                    </html:aside>
+                    <html:figure epub:type="sidebar">
+                        <html:h1>Sidebar 2</html:h1>
+                    </html:figure>
+                </html:section>
+            </x:context>
+            <x:expect label="the headlines should become hd elements">
+                <dtbook:level1>
+                    <dtbook:sidebar render="optional">
+                        <dtbook:hd>Sidebar 1</dtbook:hd>
+                    </dtbook:sidebar>
+                    <dtbook:sidebar render="required">
+                        <dtbook:hd>Sidebar 2</dtbook:hd>
+                    </dtbook:sidebar>
+                </dtbook:level1>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
 
     <!-- attlist.sidebar -->
@@ -810,20 +832,50 @@
 
     <!-- poem -->
     <x:scenario label="when processing an element with an epub:type of z3998:poem">
-        <x:context>
-            <html:div>
-                <html:span epub:type="z3998:poem"/>
-                <html:p epub:type="z3998:poem"/>
-                <html:div epub:type="z3998:poem"/>
-            </html:div>
-        </x:context>
-        <x:expect label="the resulting element should be a poem">
-            <dtbook:div>
-                <dtbook:poem/>
-                <dtbook:poem/>
-                <dtbook:poem/>
-            </dtbook:div>
-        </x:expect>
+        <x:scenario label="and no content">
+            <x:context>
+                <html:div>
+                    <html:span epub:type="z3998:poem"/>
+                    <html:p epub:type="z3998:poem"/>
+                    <html:div epub:type="z3998:poem"/>
+                </html:div>
+            </x:context>
+            <x:expect label="the resulting element should be a poem">
+                <dtbook:div>
+                    <dtbook:poem/>
+                    <dtbook:poem/>
+                    <dtbook:poem/>
+                </dtbook:div>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="with a headline inside">
+            <x:context>
+                <html:section>
+                    <html:span epub:type="z3998:poem">
+                        <html:h1>Poem 1</html:h1>
+                    </html:span>
+                    <html:p epub:type="z3998:poem">
+                        <html:h1>Poem 2</html:h1>
+                    </html:p>
+                    <html:div epub:type="z3998:poem">
+                        <html:h1>Poem 3</html:h1>
+                    </html:div>
+                </html:section>
+            </x:context>
+            <x:expect label="the resulting headlines should become hd elements">
+                <dtbook:level1>
+                    <dtbook:poem>
+                        <dtbook:hd>Poem 1</dtbook:hd>
+                    </dtbook:poem>
+                    <dtbook:poem>
+                        <dtbook:hd>Poem 2</dtbook:hd>
+                    </dtbook:poem>
+                    <dtbook:poem>
+                        <dtbook:hd>Poem 3</dtbook:hd>
+                    </dtbook:poem>
+                </dtbook:level1>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
 
     <!-- attlist.poem -->
@@ -2948,6 +3000,42 @@
                     </dtbook:list>
                 </dtbook:li>
             </dtbook:list>
+        </x:expect>
+    </x:scenario>
+
+    <x:scenario label="issue #252 - wrap inline content in epub:type=rearnote in a p">
+        <x:context>
+            <html:ol epub:type="rearnotes">
+                <html:li epub:type="rearnote" class="notebody" id="rn1">1 Rearnote</html:li>
+                <html:li epub:type="rearnote" class="notebody" id="rn2"><html:span>2 Rearnote</html:span></html:li>
+                <html:li epub:type="rearnote" class="notebody" id="rn3"><html:p>3 Rearnote</html:p></html:li>
+                <html:li epub:type="rearnote" class="notebody" id="rn4">
+                    <!-- comment -->
+                    <![CDATA[   ]]>
+                    <html:p>4 Rearnote</html:p>
+                </html:li>
+            </html:ol>
+            <html:ol epub:type="footnotes">
+                <html:li id="fn_102" class="notebody" epub:type="footnote">
+                    <html:p>
+                        <html:span id="dtb1121">Henri 1987</html:span>
+                    </html:p>
+                </html:li>
+            </html:ol>
+        </x:context>
+        <x:expect label="the text node and the span element should be wrapped in a p, while the p should not be wrapped in another p">
+            <dtbook:note id="rn1"><dtbook:p>1 Rearnote</dtbook:p></dtbook:note>
+            <dtbook:note id="rn2"><dtbook:p><dtbook:span>2 Rearnote</dtbook:span></dtbook:p></dtbook:note>
+            <dtbook:note id="rn3"><dtbook:p>3 Rearnote</dtbook:p></dtbook:note>
+            <dtbook:note id="rn4">
+                <!-- comment -->
+                <dtbook:p>4 Rearnote</dtbook:p>
+            </dtbook:note>
+            <dtbook:note id="fn_102">
+                <dtbook:p>
+                    <dtbook:span id="dtb1121">Henri 1987</dtbook:span>
+                </dtbook:p>
+            </dtbook:note>
         </x:expect>
     </x:scenario>
 


### PR DESCRIPTION
- added validation rule nordic268: heading levels must be nested correctly; h1, h2, h3 etc.
- use hd for headlines in sidebars and poems, fixes #251
- added tests for hd element in sidebars and poems
- wrap inline content in notes in p elements, fixes #252
