### PR TITLE
Handle the case when an epigraph is inside a p

### DIFF
--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -1119,7 +1119,7 @@
 
     <xsl:template match="dtbook:p">
         <xsl:variable name="element" select="."/>
-        <xsl:variable name="has-block-elements" select="if (dtbook:list or dtbook:dl or dtbook:imggroup) then true() else false()"/>
+        <xsl:variable name="has-block-elements" select="if (dtbook:list or dtbook:dl or dtbook:imggroup or dtbook:epigraph) then true() else false()"/>
         <xsl:variable name="contains-single-code-element" select="count(dtbook:code) = 1 and count(* | text()[normalize-space()]) = 1"/>
         <xsl:if test="f:classes($element)=('precedingemptyline','precedingseparator')">
             <hr class="{if (f:classes($element)='precedingseparator') then 'separator' else 'emptyline'}"/>
@@ -1130,7 +1130,7 @@
                 <xsl:with-param name="except-classes" select="('precedingemptyline','precedingseparator')" tunnel="yes"/>
                 <xsl:with-param name="except" select="if (not($has-block-elements) and $contains-single-code-element) then 'xml:space' else ()" tunnel="yes"/>
             </xsl:call-template>
-            <xsl:for-each-group select="node()" group-adjacent="not(self::dtbook:list or self::dtbook:dl or self::dtbook:imggroup)">
+            <xsl:for-each-group select="node()" group-adjacent="not(self::dtbook:list or self::dtbook:dl or self::dtbook:imggroup or self::dtbook:epigraph)">
                 <xsl:choose>
                     <xsl:when test="current-grouping-key()">
                         <xsl:choose>

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -821,12 +821,26 @@
 
     <!-- epigraph -->
     <x:scenario label="when processing a epigraph element">
-        <x:context>
-            <dtbook:epigraph/>
-        </x:context>
-        <x:expect label="the resulting element should be a p with an added epub:type of epigraph">
-            <html:p id="..." epub:type="epigraph" class="epigraph"/>
-        </x:expect>
+	<x:scenario label="on its own">
+            <x:context>
+		<dtbook:epigraph/>
+            </x:context>
+            <x:expect label="the resulting element should be a p with an added epub:type of epigraph">
+		<html:p id="..." epub:type="epigraph" class="epigraph"/>
+            </x:expect>
+	</x:scenario>
+	<x:scenario label="which is inside a p">
+            <x:context>
+		<dtbook:p>foo<dtbook:epigraph/>bar</dtbook:p>
+            </x:context>
+            <x:expect label="the resulting element should be a div with multiple parallel paragraphs inside">
+		<html:div>
+		    <html:p>foo</html:p>
+		    <html:p id="..." epub:type="epigraph" class="epigraph"/>
+		    <html:p>bar</html:p>
+		</html:div>
+            </x:expect>
+	</x:scenario>
     </x:scenario>
 
     <!-- attlist.epigraph -->


### PR DESCRIPTION
When an epigraph is used inside a p we should take care not to emit a
p inside a p as this is not permitted. Instead we enhance the
`has-block-elements` functionality of the `dtbook:p` matcher.

Fixes #362