### PR TITLE
Render inline prodnotes as spans

### DIFF
--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -536,20 +536,19 @@
     </xsl:template>
 
     <xsl:template match="dtbook:prodnote | dtbook:div[f:classes(.) = ('prodnote','production')]">
-        <xsl:choose>
-            <xsl:when test="parent::*[tokenize(@class,'\s+')=('cover','jacketcopy')]">
-                <section>
-                    <xsl:call-template name="f:attlist.prodnote"/>
-                    <xsl:apply-templates select="node()"/>
-                </section>
-            </xsl:when>
-            <xsl:otherwise>
-                <aside>
-                    <xsl:call-template name="f:attlist.prodnote"/>
-                    <xsl:apply-templates select="node()"/>
-                </aside>
-            </xsl:otherwise>
-        </xsl:choose>
+      <xsl:element name="{if (parent::*[tokenize(@class,'\s+')=('cover','jacketcopy')]) then 'section'
+			  else 'aside'}">
+        <xsl:call-template name="f:attlist.prodnote"/>
+        <xsl:apply-templates select="node() | text()"/>
+      </xsl:element>
+    </xsl:template>
+
+    <!-- Render inline prodnotes as spans -->
+    <xsl:template match="dtbook:prodnote[f:is-inline(./parent::dtbook:*) and not(./parent::dtbook:imggroup)]">
+      <span>
+        <xsl:call-template name="f:attlist.prodnote"/>
+        <xsl:apply-templates select="node() | text()"/>
+      </span>
     </xsl:template>
 
     <xsl:template name="f:attlist.prodnote">

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -726,6 +726,15 @@
                 </html:section>
             </x:expect>
         </x:scenario>
+        <x:scenario label="which is inside a paragraph">
+            <x:context>
+		<dtbook:p>
+                <dtbook:prodnote render="optional">This is a prodnote</dtbook:prodnote>I wish I was a little test</dtbook:p>
+            </x:context>
+            <x:expect label="the resulting element should be a span">
+		<html:p><html:span epub:type="z3998:production" class="prodnote render-optional" id="...">This is a prodnote</html:span>I wish I was a little test</html:p>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
 
     <!-- attlist.prodnote -->


### PR DESCRIPTION
Without this change inline prodnotes are rendered as asides. So you
might end up with non-valid EPUB as asides aren't allowed inside a
paragraph.

Fixes #363