### PR TITLE
Retain dtbook:hd inside dtbook:list

### DIFF
--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -1309,6 +1309,7 @@
             <xsl:when test="dtbook:hd">
                 <section>
                     <xsl:attribute name="id" select="f:generate-pseudorandom-id(concat(f:generate-pretty-id(.,$all-ids),'_section'),$all-ids)"/>
+                    <xsl:apply-templates select="dtbook:hd"/>
                     <xsl:call-template name="f:list.content">
                         <xsl:with-param name="all-ids" select="$all-ids" tunnel="yes"/>
                     </xsl:call-template>

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -2338,8 +2338,11 @@
                     <dtbook:hd>TEXT</dtbook:hd>
                 </dtbook:list>
             </x:context>
-            <x:expect label="the resulting list should be wrapped in a section element">
-                <html:section id="...">...</html:section>
+            <x:expect label="the resulting list should be wrapped in a section element containing the hd">
+                <html:section id="...">
+		    <html:h1 id="...">TEXT</html:h1>
+		    <html:ol id="..." class="list-style-type-none">...</html:ol>
+	        </html:section>
             </x:expect>
         </x:scenario>
         <x:scenario label="which is ordered">


### PR DESCRIPTION
Do not drop hd inside a list.

This fixes #369