### PR TITLE
Render dtbook:epigraph as html:blockquote

### DIFF
--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -1787,7 +1787,7 @@
     or a division of a work.
   -->
     <define name="epigraph">
-        <element name="p">
+        <element name="blockquote">
             <!-- HTML content model: (a | abbr | audio | b | bdi | bdo | br | button | canvas | cite | code | data | datalist | del | dfn | em | embed | i | iframe | img | input | ins | kbd | keygen | label | link | map | mark | math | meta | meter | noscript | object | output | progress | q | ruby | s | samp | script | select | small | span | strong | sub | sup | svg | template | textarea | time | u | var | video | wbr | (text))* -->
             <!-- Strict content model: (em | strong | dfn | code | samp | kbd | abbr | a | img | br | q | sub | sup | span | bdo | (text))* -->
             <ref name="attlist.epigraph"/>

--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -92,7 +92,7 @@
             <ref name="linegroup"/> <!-- section, div -->
             <ref name="byline"/> <!-- span -->
             <ref name="dateline"/> <!-- span -->
-            <ref name="epigraph"/> <!-- p -->
+            <ref name="epigraph"/> <!-- blockquote -->
             <ref name="table"/> <!-- table -->
             <ref name="address"/> <!-- address -->
             <ref name="line"/> <!-- p -->
@@ -113,7 +113,7 @@
             <ref name="linegroup"/> <!-- section, div -->
             <ref name="byline"/> <!-- span -->
             <ref name="dateline"/> <!-- span -->
-            <ref name="epigraph"/> <!-- p -->
+            <ref name="epigraph"/> <!-- blockquote -->
             <ref name="table"/> <!-- table -->
             <ref name="address"/> <!-- address -->
             <ref name="line"/> <!-- p -->
@@ -134,7 +134,7 @@
             <ref name="linegroup"/> <!-- section, div -->
             <ref name="byline"/> <!-- span -->
             <ref name="dateline"/> <!-- span -->
-            <ref name="epigraph"/> <!-- p -->
+            <ref name="epigraph"/> <!-- blockquote -->
             <ref name="address"/> <!-- address -->
             <ref name="line"/> <!-- p -->
             <ref name="htmlblocknoimggroup"/> <!-- span, aside, section -->
@@ -1884,7 +1884,7 @@
         <zeroOrMore>
             <choice>
                 <ref name="dateline"/> <!-- span -->
-                <ref name="epigraph"/> <!-- p -->
+                <ref name="epigraph"/> <!-- blockquote -->
                 <ref name="byline"/> <!-- span -->
                 <ref name="linegroup"/> <!-- section, div -->
                 <ref name="line"/> <!-- p -->
@@ -1936,7 +1936,7 @@
                     <ref name="author.block"/> <!-- p -->
                     <ref name="hd"/> <!-- h1, h2, h3, h4, h5, h6 -->
                     <ref name="dateline"/> <!-- span -->
-                    <ref name="epigraph"/> <!-- p -->
+                    <ref name="epigraph"/> <!-- blockquote -->
                     <ref name="byline"/> <!-- span -->
                     <ref name="linegroup"/> <!-- section, div -->
                     <ref name="line"/> <!-- p -->

--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -1783,7 +1783,7 @@
     <!-- ====================== Byline, Epigraph, Dateline ===================== -->
     
     <!--
-    Use: epigraph marks a quotation placed at the beginnihg of a work
+    Use: epigraph marks a quotation placed at the beginning of a work
     or a division of a work.
   -->
     <define name="epigraph">

--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -1787,14 +1787,22 @@
     or a division of a work.
   -->
     <define name="epigraph">
-        <element name="blockquote">
-            <!-- HTML content model: (a | abbr | audio | b | bdi | bdo | br | button | canvas | cite | code | data | datalist | del | dfn | em | embed | i | iframe | img | input | ins | kbd | keygen | label | link | map | mark | math | meta | meter | noscript | object | output | progress | q | ruby | s | samp | script | select | small | span | strong | sub | sup | svg | template | textarea | time | u | var | video | wbr | (text))* -->
-            <!-- Strict content model: (em | strong | dfn | code | samp | kbd | abbr | a | img | br | q | sub | sup | span | bdo | (text))* -->
-            <ref name="attlist.epigraph"/>
-            <zeroOrMore>
-                <ref name="flow"/> <!-- em, strong, dfn, code, samp, kbd, abbr, a, img, figure, br, q, sub, sup, span, bdo, p, ol, ul, dl, div, blockquote, table, address, section, (text) -->
-            </zeroOrMore>
-        </element>
+        <choice>
+            <element name="blockquote">
+                <!-- HTML content model: (a | abbr | audio | b | bdi | bdo | br | button | canvas | cite | code | data | datalist | del | dfn | em | embed | i | iframe | img | input | ins | kbd | keygen | label | link | map | mark | math | meta | meter | noscript | object | output | progress | q | ruby | s | samp | script | select | small | span | strong | sub | sup | svg | template | textarea | time | u | var | video | wbr | (text))* -->
+                <!-- Strict content model: (em | strong | dfn | code | samp | kbd | abbr | a | img | br | q | sub | sup | span | bdo | (text))* -->
+                <ref name="attlist.epigraph"/>
+                <zeroOrMore>
+                    <ref name="flow"/> <!-- em, strong, dfn, code, samp, kbd, abbr, a, img, figure, br, q, sub, sup, span, bdo, p, ol, ul, dl, div, blockquote, table, address, section, (text) -->
+                </zeroOrMore>
+            </element>
+            <element name="p"> <!-- for backwards compatibility we still allow p -->
+                <ref name="attlist.epigraph"/>
+                <zeroOrMore>
+                   <ref name="inline"/> <!-- em, strong, dfn, code, samp, kbd, abbr, a, img, br, q, sub, sup, span, bdo, (text) -->
+                </zeroOrMore>
+            </element>
+        </choice>
     </define>
     <define name="attlist.epigraph" combine="interleave">
         <attribute name="epub:type">

--- a/src/main/resources/xml/schema/nordic-html5.rng
+++ b/src/main/resources/xml/schema/nordic-html5.rng
@@ -1792,7 +1792,7 @@
             <!-- Strict content model: (em | strong | dfn | code | samp | kbd | abbr | a | img | br | q | sub | sup | span | bdo | (text))* -->
             <ref name="attlist.epigraph"/>
             <zeroOrMore>
-                <ref name="inline"/> <!-- em, strong, dfn, code, samp, kbd, abbr, a, img, br, q, sub, sup, span, bdo, (text) -->
+                <ref name="flow"/> <!-- em, strong, dfn, code, samp, kbd, abbr, a, img, figure, br, q, sub, sup, span, bdo, p, ol, ul, dl, div, blockquote, table, address, section, (text) -->
             </zeroOrMore>
         </element>
     </define>

--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -646,10 +646,10 @@
     </xsl:template>
 
     <xsl:template match="dtbook:epigraph">
-        <p>
+        <blockquote>
             <xsl:call-template name="f:attlist.epigraph"/>
             <xsl:apply-templates select="node()"/>
-        </p>
+        </blockquote>
     </xsl:template>
 
     <xsl:template name="f:attlist.epigraph">

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -820,13 +820,34 @@
     <!-- implicit epub:type tested in element test, otherwise nothing interesting to test -->
 
     <!-- epigraph -->
+    <!-- The nordic guidelines do not allow for epigraph. So the
+         following is for completeness sake and takes some inspiration
+         from https://www.w3.org/TR/dpub-aria-1.0/#doc-epigraph -->
     <x:scenario label="when processing a epigraph element">
-        <x:context>
-            <dtbook:epigraph/>
-        </x:context>
-        <x:expect label="the resulting element should be a p with an added epub:type of epigraph">
-            <html:p id="..." epub:type="epigraph" class="epigraph"/>
-        </x:expect>
+	<x:scenario label="on its own">
+            <x:context>
+		<dtbook:epigraph/>
+            </x:context>
+            <x:expect label="the resulting element should be a blockquote with an added epub:type of epigraph">
+		<html:blockquote id="..." epub:type="epigraph" class="epigraph"/>
+            </x:expect>
+	</x:scenario>
+	<x:scenario label="which is inside a p">
+            <x:context>
+		<dtbook:p>foo<dtbook:epigraph/>bar</dtbook:p>
+            </x:context>
+            <x:expect label="the resulting element should be a p with a blockquote inside">
+	        <html:p>foo<html:blockquote id="..." epub:type="epigraph" class="epigraph"/>bar</html:p>
+            </x:expect>
+	</x:scenario>
+	<x:scenario label="which contains a p">
+            <x:context>
+		<dtbook:epigraph><dtbook:p>foo</dtbook:p></dtbook:epigraph>
+            </x:context>
+            <x:expect label="the resulting element should be a blockquote with a p inside">
+	        <html:blockquote id="..." epub:type="epigraph" class="epigraph"><html:p>foo</html:p></html:blockquote>
+            </x:expect>
+	</x:scenario>
     </x:scenario>
 
     <!-- attlist.epigraph -->

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -832,14 +832,6 @@
 		<html:blockquote id="..." epub:type="epigraph" class="epigraph"/>
             </x:expect>
 	</x:scenario>
-	<x:scenario label="which is inside a p">
-            <x:context>
-		<dtbook:p>foo<dtbook:epigraph/>bar</dtbook:p>
-            </x:context>
-            <x:expect label="the resulting element should be a p with a blockquote inside">
-	        <html:p>foo<html:blockquote id="..." epub:type="epigraph" class="epigraph"/>bar</html:p>
-            </x:expect>
-	</x:scenario>
 	<x:scenario label="which contains a p">
             <x:context>
 		<dtbook:epigraph><dtbook:p>foo</dtbook:p></dtbook:epigraph>


### PR DESCRIPTION
This solves the issue that a p inside an epigraph can cause invalid
html. It also follows a recommendation by WAI-ARIA.

Fixes #368 

This PR replaces #365