### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use a multistage build to first build the migrator using maven. Then
+# copy the artifacts into a final image which exposes the port and
+# starts the pipeline.
+
+# Build the pipeline first
+FROM maven:3.5-jdk-8 as builder
+ADD . /usr/src/nordic-epub3-dtbook-migrator
+WORKDIR /usr/src/nordic-epub3-dtbook-migrator
+RUN mvn clean package
+
+# then use the build artifacts to create an image where the pipeline is installed
+FROM daisyorg/pipeline-assembly
+LABEL maintainer="Norwegian library of talking books and braille (http://www.nlb.no/)"
+COPY --from=builder /usr/src/nordic-epub3-dtbook-migrator/target/nordic-epub3-dtbook-migrator-*.jar /opt/daisy-pipeline2/modules/
+ENV PIPELINE2_WS_LOCALFS=false \
+    PIPELINE2_WS_AUTHENTICATION=true \
+    PIPELINE2_WS_AUTHENTICATION_KEY=clientid \
+    PIPELINE2_WS_AUTHENTICATION_SECRET=sekret
+EXPOSE 8181
+# for the healthcheck use PIPELINE2_HOST if defined. Otherwise use localhost
+HEALTHCHECK --interval=30s --timeout=10s --start-period=1m CMD curl --fail http://${PIPELINE2_WS_HOST-localhost}:${PIPELINE2_WS_PORT:-8181}/${PIPELINE2_WS_PATH:-ws}/alive || exit 1
+ENTRYPOINT ["/opt/daisy-pipeline2/bin/pipeline2"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This tool attempts to map EPUB3 to DTBook with as little loss as possible (a 1:1
 While the EPUB3 will consist of multiple HTML files internally, an intermediate
 single-page HTML representation is useful for converting to and from DTBook.
 
+Scripts
+-------
+
 This project provides the following Pipeline 2 scripts:
 
  * EPUB3 to DTBook
@@ -56,6 +59,24 @@ and is defined in the Nordic markup guidelines. Most DTBooks will work with thes
 there are few limitations to the input DTBook grammar. There are more limitations to the HTML/EPUB3
 grammar however, because there must be a way to convert it to DTBook.
 Most notably, multimedia such as audio and video are currently not allowed in these EPUB3s.
+
+Building
+--------
+
+To create a docker image type
+
+```shell
+docker build -t nlbdev/epub3-dtbook-migrator .
+```
+
+To run the docker image type
+
+```shell
+docker run --rm -e PIPELINE2_WS_HOST=0.0.0.0 -p 8181:8181 nlbdev/nordic-epub3-dtbook-migrator
+```
+
+References
+----------
 
 See [the project homepage](http://nlbdev.github.io/nordic-epub3-dtbook-migrator/) for more information.
 


### PR DESCRIPTION
that creates an image containing the migrator on top of the latest DAISY pipeline2 image.

Fixes #373