### PR TITLE
Map dtbook:poem to a html:div if it doesn't contain a headline

### DIFF
--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -700,10 +700,10 @@
     </xsl:template>
 
     <xsl:template match="dtbook:poem">
-        <section>
+        <xsl:element name="{if (dtbook:hd) then 'section' else 'div'}">
             <xsl:call-template name="f:attlist.poem"/>
             <xsl:apply-templates select="node()"/>
-        </section>
+	</xsl:element>
     </xsl:template>
 
     <xsl:template name="f:attlist.poem">

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -895,9 +895,9 @@
                 </dtbook:poem>
             </x:context>
             <x:expect label="the resulting element should be given an added epub:type of z3998:verse">
-                <html:section id="..." epub:type="z3998:poem" class="poem">
+                <html:div id="..." epub:type="z3998:poem" class="poem">
                     <html:div id="..." class="linegroup" epub:type="z3998:verse"/>
-                </html:section>
+                </html:div>
             </x:expect>
         </x:scenario>
     </x:scenario>
@@ -931,8 +931,8 @@
             <x:context>
                 <dtbook:poem/>
             </x:context>
-            <x:expect label="the resulting element should also be a section with an added epub:type of z3998:poem">
-                <html:section id="..." epub:type="z3998:poem" class="poem"/>
+            <x:expect label="the resulting element should also be a div with an added epub:type of z3998:poem">
+                <html:div id="..." epub:type="z3998:poem" class="poem"/>
             </x:expect>
         </x:scenario>
     </x:scenario>


### PR DESCRIPTION
According to the [mapping document](http://nlbdev.github.io/nordic-epub3-dtbook-migrator/mapping.html) a `dtbook:poem` should be converted to a `html:section` if it does contain a `dtbook:hd` and to a `html:div` otherwise.

Fixes #374