### PR TITLE
Fix for "Cannot convert double nan to an integer"

### DIFF
--- a/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
+++ b/src/main/resources/xml/xslt/dtbook-to-epub3.xsl
@@ -1328,7 +1328,7 @@
         </xsl:apply-templates>
         <xsl:variable name="first-marker-text" select="dtbook:li[1]/(text()[1] | dtbook:p/text()[1])[normalize-space()][1]"/>
         <xsl:variable name="first-marker"
-            select="if (starts-with($first-marker-text,'•')) then '•' else if (matches($first-marker-text,'^[0-9a-zA-Z]+\.')) then replace($first-marker-text,'^([0-9a-zA-Z]+)\..*','$1') else ''"/>
+            select="if (starts-with($first-marker-text,'•')) then '•' else if (matches($first-marker-text,'^[0-9a-zA-Z]+\.')) then substring-before($first-marker-text,'.') else ''"/>
         <xsl:variable name="first-marker-type"
             select="if (not($first-marker)) then '' else if ($first-marker='•') then '•' else if (string(number($first-marker)) != 'NaN') then '1' else if ($first-marker='i') then 'i' else if ($first-marker='I') then 'I' else if ($first-marker=lower-case($first-marker)) then 'a' else 'A'"/>
         <xsl:element name="{if ($first-marker-type='•') then 'ul' else 'ol'}">
@@ -1366,7 +1366,7 @@
         <li>
             <xsl:variable name="marker-text" select="(text() | dtbook:p/text())[normalize-space()][1]"/>
             <xsl:variable name="marker"
-                select="if (starts-with($marker-text,'•')) then '•' else if (matches($marker-text,'^[0-9a-zA-Z]+\.')) then replace($marker-text,'^([0-9a-zA-Z]+)\..*','$1') else ()"/>
+                select="if (starts-with($marker-text,'•')) then '•' else if (matches($marker-text,'^[0-9a-zA-Z]+\.')) then substring-before($marker-text,'.') else ()"/>
             <xsl:variable name="marker-type"
                 select="if (not($marker)) then '' else if ($marker='•') then '•' else if (string(number($marker)) != 'NaN') then '1' else parent::*/dtbook:li[1]/(text()[normalize-space()]|dtbook:p/text()[normalize-space()])[1]/(if (starts-with(.,'i.')) then 'i' else if (starts-with(.,'I.')) then 'I' else if (substring(.,1,1)=lower-case(substring(.,1,1))) then 'a' else 'A')"/>
             <!-- NOTE: list is assumed to be preformatted; a generic script would calculate implicit value based on start attribute etc. -->

--- a/src/test/xspec/dtbook-to-epub3.xspec
+++ b/src/test/xspec/dtbook-to-epub3.xspec
@@ -2574,6 +2574,20 @@
                 </html:ol>
             </x:expect>
         </x:scenario>
+        <x:scenario label="inside a preformatted list containing a very long text">
+            <x:context>
+                <dtbook:list type="pl" depth="1">
+		  <dtbook:li>2. Halten Sie
+		  Sie es tunlichst, der Öffentlichkeit jene Hautfladen auch bekannt als Bingofladen, die unter den Oberarmen hängen, zuzumuten. Dasselbe gilt für die Röllchen unter der Achsel, zwischen Oberarm und Oberkörper.</dtbook:li>
+                </dtbook:list>
+            </x:context>
+            <x:expect label="the type of list should be detected, the list markers removed and the value should be correct">
+                <html:ol id="...">
+                    <html:li id="..." value="2">Halten Sie
+		  Sie es tunlichst, der Öffentlichkeit jene Hautfladen auch bekannt als Bingofladen, die unter den Oberarmen hängen, zuzumuten. Dasselbe gilt für die Röllchen unter der Achsel, zwischen Oberarm und Oberkörper.</html:li>
+                </html:ol>
+            </x:expect>
+        </x:scenario>
         <x:scenario label="with ol and reversed order">
             <x:context>
                 <dtbook:list type="pl" depth="1">


### PR DESCRIPTION
When extracting the marker from a `dtbook:li` the regexp seems to run into some problems in some corner cases (probably new line combined with very long text inside the `dtbook:li`. This PR uses `substring-before` and should be more robust. All tests pass.

Fixes nlbdev/nordic-epub3-dtbook-migrator#378