### PR TITLE
Fixing rule with epub:type not allowed for body element

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -102,17 +102,6 @@
         </rule>
     </pattern>
 
-    <pattern id="epub_nordic_13_f">
-        <title>Rule 13f</title>
-        <p>All top sections need aria information</p>
-        <rule context="html:body/html:section">
-            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="@role">[nordic13f] The top-level section element must have a aria role. <value-of select="$context"/></assert>
-            <assert test="@aria-labelledby or @aria-label">The top-level section element must have an aria-label or a labelledby attribute. <value-of select="$context"/></assert>
-            <assert test="not(@aria-labelledby) or (@aria-labelledby = (html:h1|html:h2|html:h3|html:h4|html:h5|html:h6)[1]/@id)">[nordic13f] The top-level section element labelledby attribute must be associated with the first header in the section.</assert>
-        </rule>
-    </pattern>
-
     <pattern id="epub_nordic_15">
         <title>Rule 15</title>
         <p></p>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -95,13 +95,24 @@
     
     <pattern id="epub_nordic_13_e">
         <title>Rule 13e</title>
-        <p></p>
+        <p>The body element must not have a epub:type attribute.</p>
         <rule context="html:body">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="@epub:type">[nordic13e] The body element must not have a epub:type attribute.</assert>
         </rule>
     </pattern>
-    
+
+    <pattern id="epub_nordic_13_f">
+        <title>Rule 13f</title>
+        <p>All top sections need aria information</p>
+        <rule context="html:body/html:section">
+            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
+            <assert test="@role">[nordic13f] The top-level section element must have a aria role. <value-of select="$context"/></assert>
+            <assert test="@aria-labelledby or @aria-label">The top-level section element must have an aria-label or a labelledby attribute. <value-of select="$context"/></assert>
+            <assert test="not(@aria-labelledby) or (@aria-labelledby = (html:h1|html:h2|html:h3|html:h4|html:h5|html:h6)[1]/@id)">[nordic13f] The top-level section element labelledby attribute must be associated with the first header in the section.</assert>
+        </rule>
+    </pattern>
+
     <pattern id="epub_nordic_15">
         <title>Rule 15</title>
         <p></p>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -98,7 +98,7 @@
         <p>The body element must not have a epub:type attribute.</p>
         <rule context="html:body">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="@epub:type">[nordic13e] The body element must not have a epub:type attribute.</assert>
+            <assert test="not(@epub:type)">[nordic13e] The body element must not have a epub:type attribute.</assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Hi @josteinaj 

I've now changed this PR only to have the epub:type fix.

The aria rules will either be checked by ACE or be added in a later revision per our meeting.

Best regards
Daniel