### PR TITLE
Making changes to handle the first 6 comments on the content structure.

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -909,8 +909,14 @@
         <ref name="attlist.level1"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
         <choice>
             <group>
-                <ref name="h1"/> <!-- h1 -->
-                <ref name="h2"/> <!-- h2 -->
+                <choice>
+                    <ref name="h1"/> <!-- h1 -->
+                    <ref name="h2"/> <!-- h2 -->
+                    <ref name="h3"/> <!-- h3 -->
+                    <ref name="h4"/> <!-- h4 -->
+                    <ref name="h5"/> <!-- h5 -->
+                    <ref name="h6"/> <!-- h6 -->
+                </choice>
                 <oneOrMore>
                     <choice>
                         <ref name="docblockorinline"/> <!-- p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math -->
@@ -926,8 +932,14 @@
                     </choice>
                 </oneOrMore>
                 <optional>
-                    <ref name="h1"/> <!-- h1 -->
-                    <ref name="h2"/> <!-- h2 -->
+                    <choice>
+                        <ref name="h1"/> <!-- h1 -->
+                        <ref name="h2"/> <!-- h2 -->
+                        <ref name="h3"/> <!-- h3 -->
+                        <ref name="h4"/> <!-- h4 -->
+                        <ref name="h5"/> <!-- h5 -->
+                        <ref name="h6"/> <!-- h6 -->
+                    </choice>
                     <oneOrMore>
                         <choice>
                             <ref name="docblockorinline"/> <!-- p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math -->

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -392,7 +392,7 @@
         <a:documentation>htmlContent designates that each html has a &lt;head&gt; of
             metainformation preceding the &lt;book&gt; content.</a:documentation>
         <ref name="head"/> <!-- head -->
-        <ref name="book"/> <!-- body -->
+        <ref name="document-content"/> <!-- body -->
     </define>
     
     <define name="html">
@@ -652,7 +652,7 @@
     
     <a:documentation>Body Content</a:documentation>
     
-    <define name="book">
+    <define name="document-content">
         <!--
         Use: body surrounds the actual content of the document.
         <head>, which contains metadata, precedes <body>.
@@ -663,14 +663,6 @@
             <!-- HTML content model: a & abbr & address & article & aside & audio & b & bdi & bdo & blockquote & br & button & canvas & cite & code & data & datalist & del & details & dfn & dialog & div & dl & em & embed & fieldset & figure & footer & form & h1 & h2 & h3 & h4 & h5 & h6 & header & hr & i & iframe & img & input & ins & kbd & keygen & label & link & main & map & mark & math & menu & meta & meter & nav & noscript & object & ol & output & p & pre & progress & q & ruby & s & samp & script & section & select & small & span & strong & style & sub & sup & svg & table & template & textarea & time & u & ul & var & video & wbr & (text) -->
             <!-- Strict content model: (h1 p)? (section | article) -->
             <choice>
-                <choice>
-                    <a:documentation>multi-page HTML.</a:documentation>
-                    <!-- multi-page HTML -->
-                    <ref name="cover"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, section -->
-                    <ref name="frontmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                    <ref name="bodymatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, h1, p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                    <ref name="backmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                </choice>
                 <group>
                     <a:documentation>single-page HTML.</a:documentation>
                     <!-- single-page HTML -->
@@ -688,23 +680,14 @@
                         </zeroOrMore>
                     </element>
                     <oneOrMore>
-                        <choice>
-                           <element name="section">
-                               <choice>
-                                   <ref name="cover"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, section -->
-                                   <ref name="frontmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                                   <ref name="bodymatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, h1, p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                                   <ref name="backmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                               </choice>
-                           </element>
-                           <element name="article">
-                               <a:documentation>"article" should be used for magazine or newspaper articles. Otherwise, "section" should be used.</a:documentation>
-                               <!-- "article" should be used for magazine or newspaper articles. Otherwise, "section" should be used. -->
-                               <choice>
-                                   <ref name="bodymatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, h1, p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                               </choice>
-                           </element>
-                       </choice>
+                       <element name="section">
+                           <choice>
+                               <ref name="cover"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, section -->
+                               <ref name="frontmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
+                               <ref name="bodymatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, h1, p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math, article -->
+                               <ref name="backmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
+                           </choice>
+                       </element>
                    </oneOrMore>
                 </group>
                 <group>
@@ -927,6 +910,7 @@
         <choice>
             <group>
                 <ref name="h1"/> <!-- h1 -->
+                <ref name="h2"/> <!-- h2 -->
                 <oneOrMore>
                     <choice>
                         <ref name="docblockorinline"/> <!-- p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math -->
@@ -943,6 +927,7 @@
                 </oneOrMore>
                 <optional>
                     <ref name="h1"/> <!-- h1 -->
+                    <ref name="h2"/> <!-- h2 -->
                     <oneOrMore>
                         <choice>
                             <ref name="docblockorinline"/> <!-- p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math -->
@@ -4083,7 +4068,7 @@
                 <value>preamble</value>
                 <!--<value>preface</value>-->
                 <!--<value>prologue</value>-->
-                <value>rearnote</value>
+                <!--<value>rearnote</value>-->
                 <value>endnote</value>
                 <!--<value>rearnotes</value>-->
                 <!--<value>endnotes</value>-->


### PR DESCRIPTION
Hi @josteinaj 

I've started to look into the RelaxNG files today and update the rules after the comments made on GitHub. Some of them are quite broad so I might have misunderstood the range of the change.

1. define name="book" is not descriptive in a multipage html validation setting
2. top-level section is mandatory and should have the semantic attributes currently placed on body, body should not have any semantic attributes
3. attribute role should be allowed in every location where epub:type is currently allowed (however, there is not a 1-1 relationship between epub:type and role, in some places a matching role is not available, so it shouldn't be always required)
4. types: remove all z3998 values? No, rather make them optional!
5. types: update epub:type list based on https://idpf.github.io/epub-vocabs/structure/ (e.g. rearnotes are deprecated in favour of endnotes)
6. level1.content: currently h1 is the only allowed top-level heading, at least h2 should be allowed too, given the fact that part sectioning will have chapters starting on h2

Best regards
Daniel