### PR TITLE
Batch 3 fixes.

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -2095,21 +2095,28 @@
             <attribute name="class">
                 <value>verse</value>
             </attribute>
-            <optional>
+            <zeroOrMore>
                 <ref name="bridgehead"/>
-            </optional>
+                <ref name="poem.author"/>
+            </zeroOrMore>
             <oneOrMore>
                 <ref name="poem.linegroup"/>
             </oneOrMore>
-            <optional>
-                <element name="p">
-                    <attribute name="class">
-                        <value>verse-author</value>
-                    </attribute>
-                </element>
-            </optional>
+            <zeroOrMore>
+                <ref name="bridgehead"/>
+                <ref name="poem.author"/>
+            </zeroOrMore>
         </element>
     </define>
+
+    <define name="poem.author">
+        <element name="p">
+            <attribute name="class">
+                <value>verse-author</value>
+            </attribute>
+        </element>
+    </define>
+
 
     <define name="poem.linegroup">
         <element name="p">
@@ -2126,11 +2133,11 @@
     <define name="poem.line">
         <element name="span">
             <attribute name="class">
-                <choice>
+                <oneOrMore>
                     <value>line</value>
                     <value>line_indent</value>
                     <value>line_longindent</value>
-                </choice>
+                </oneOrMore>
             </attribute>
             <zeroOrMore>
                 <ref name="inline"/> <!-- em, strong, dfn, code, samp, kbd, span, abbr, math, a, img, br, q, sub, sup, bdo -->

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -1866,16 +1866,17 @@
         <attribute name="epub:type">
             <list>
                 <ref name="types"/>
-                <value>note</value>
                 <value>footnote</value>
                 <ref name="types"/>
             </list>
         </attribute>
-        <attribute name="class">
-            <list>
-                <ref name="classes"/>
-            </list>
-        </attribute>
+        <optional>
+            <attribute name="class">
+                <list>
+                    <ref name="classes"/>
+                </list>
+            </attribute>
+        </optional>
         <ref name="attrsrqd.base"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir -->
     </define>
     
@@ -2095,12 +2096,11 @@
                 <value>verse</value>
             </attribute>
             <optional>
-                <choice>
-                    <ref name="title"/> <!-- h1, h2, h3, h4, h5, h6 -->
-                    <ref name="bridgehead"/>
-                </choice>
+                <ref name="bridgehead"/>
             </optional>
-            <ref name="poem.linegroup"/>
+            <oneOrMore>
+                <ref name="poem.linegroup"/>
+            </oneOrMore>
             <optional>
                 <element name="p">
                     <attribute name="class">

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -1867,13 +1867,12 @@
             <list>
                 <ref name="types"/>
                 <value>note</value>
+                <value>footnote</value>
                 <ref name="types"/>
             </list>
         </attribute>
         <attribute name="class">
             <list>
-                <ref name="classes"/>
-                <value>notebody</value>
                 <ref name="classes"/>
             </list>
         </attribute>
@@ -2088,55 +2087,70 @@
             </attribute>
         </optional>
     </define>
-    
+
     <define name="poem">
-        <!-- Use: poem is a complete poem or fragment thereof. -->
         <a:documentation>  Use: poem is a complete poem or fragment thereof.  </a:documentation>
-        <element name="section">
-            <!-- HTML content model: (a | abbr | address | article | aside | audio | b | bdi | bdo | blockquote | br | button | canvas | cite | code | data | datalist | del | details | dfn | dialog | div | dl | em | embed | fieldset | figure | footer | form | h1 | h2 | h3 | h4 | h5 | h6 | header | hr | i | iframe | img | input | ins | kbd | keygen | label | link | main | map | mark | math | menu | meta | meter | nav | noscript | object | ol | output | p | pre | progress | q | ruby | s | samp | script | section | select | small | span | strong | style | sub | sup | svg | table | template | textarea | time | u | ul | var | video | wbr | (text))* -->
-            <!-- Strict content model: (h1 | span | p | section | img | figure)* -->
-            <ref name="attlist.poem"/> <!-- @epub:type, @class, @id, @title, @xml:space, @xml:lang, @lang, @dir -->
-            <zeroOrMore>
+        <element name="div">
+            <attribute name="class">
+                <value>verse</value>
+            </attribute>
+            <optional>
                 <choice>
                     <ref name="title"/> <!-- h1, h2, h3, h4, h5, h6 -->
-                    <ref name="author.block"/> <!-- p -->
-                    <ref name="hd"/> <!-- h1, h2, h3, h4, h5, h6 -->
-                    <ref name="dateline"/> <!-- span -->
-                    <ref name="epigraph"/> <!-- blockquote, p -->
-                    <ref name="byline"/> <!-- span -->
-                    <ref name="linegroup"/> <!-- div, section -->
-                    <ref name="line"/> <!-- p -->
-                    <ref name="pagebreak.block"/> <!-- div -->
-                    <ref name="img"/> <!-- img -->
-                    <ref name="figure.imggroup"/> <!-- figure -->
-                    <ref name="sidebar"/> <!-- aside, figure -->
+                    <element name="p">
+                        <attribute name="class">
+                            <value>verse-title</value>
+                        </attribute>
+                    </element>
                 </choice>
-            </zeroOrMore>
+            </optional>
+            <ref name="poem.linegroup"/>
+            <optional>
+                <element name="p">
+                    <attribute name="class">
+                        <value>verse-author</value>
+                    </attribute>
+                </element>
+            </optional>
         </element>
     </define>
 
-    <define name="attlist.poem" combine="interleave">
-        <attribute name="epub:type">
-            <list>
-                <ref name="types"/>
-                <choice>
-                    <!-- By mistake, z:3998:verse is allowed on the poem in guidelines version 2015-1, so for now we'll allow suppliers to either follow the guidlines (z3998:verse) or do it correctly (z3998:poem) -->
-                    <value>z3998:verse</value>
-                    <value>z3998:poem</value>
-                </choice>
-                <ref name="types"/>
-            </list>
-        </attribute>
-        <attribute name="class">
-            <list>
-                <ref name="classes"/>
-                <value>poem</value>
-                <ref name="classes"/>
-            </list>
-        </attribute>
-        <ref name="attrsrqd.base"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir -->
+    <define name="poem.linegroup">
+        <element name="p">
+            <attribute name="class">
+                <value>linegroup</value>
+            </attribute>
+            <oneOrMore>
+                <ref name="poem.line"/>
+                <ref name="poem.linenum"/>
+            </oneOrMore>
+        </element>
     </define>
-    
+
+    <define name="poem.line">
+        <element name="span">
+            <attribute name="class">
+                <choice>
+                    <value>line</value>
+                    <value>line_indent</value>
+                    <value>line_longindent</value>
+                </choice>
+            </attribute>
+            <zeroOrMore>
+                <ref name="inline"/> <!-- em, strong, dfn, code, samp, kbd, span, abbr, math, a, img, br, q, sub, sup, bdo -->
+            </zeroOrMore>
+        </element>
+        <element name="br"></element>
+    </define>
+
+    <define name="poem.linenum">
+        <element name="span">
+            <attribute name="class">
+                <value>linenum</value>
+            </attribute>
+        </element>
+    </define>
+
     <a:documentation>The Anchor Element</a:documentation>
     
     <define name="a">
@@ -3451,11 +3465,7 @@
                 <list>
                     <ref name="types"/>
                     <optional>
-                        <choice>
-                            <value>rearnotes</value>
-                            <value>endnotes</value>
-                            <value>footnotes</value>
-                        </choice>
+                        <value>endnotes</value>
                     </optional>
                     <ref name="types"/>
                 </list>
@@ -4001,7 +4011,6 @@
             <value>assessments</value>
             <value>qna</value>
             <value>practices</value>
-            <value>footnotes</value>
             <value>rearnotes</value>
             <value>endnotes</value>
             <value>page-list</value>
@@ -4046,8 +4055,6 @@
                 <!--<value>epigraph</value>-->
                 <!--<value>epilogue</value>-->
                 <value>errata</value>
-                <value>footnote</value>
-                <!--<value>footnotes</value>-->
                 <!--<value>foreword</value>-->
                 <!--<value>frontmatter</value>-->
                 <value>fulltitle</value>
@@ -4421,7 +4428,6 @@
                 <value>linegroup</value>
                 <value>linenum</value>
                 <value>nonstandardpagination</value>
-                <value>notebody</value>
                 <value>noteref</value>
                 <value>page-front</value>
                 <value>page-normal</value>

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -2097,11 +2097,7 @@
             <optional>
                 <choice>
                     <ref name="title"/> <!-- h1, h2, h3, h4, h5, h6 -->
-                    <element name="p">
-                        <attribute name="class">
-                            <value>verse-title</value>
-                        </attribute>
-                    </element>
+                    <ref name="bridgehead"/>
                 </choice>
             </optional>
             <ref name="poem.linegroup"/>

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -2103,6 +2103,7 @@
                 <ref name="poem.linegroup"/>
             </oneOrMore>
             <zeroOrMore>
+                <ref name="poem.linegroup"/>
                 <ref name="bridgehead"/>
                 <ref name="poem.author"/>
             </zeroOrMore>


### PR DESCRIPTION
Hi @josteinaj 

* Remove class attribute notebody
* aside should be used for body footnotes (one aside element per footnote) only, endnotes should be in a list along the lines set out by http://kb.daisy.org/publishing/docs/html/notes.html
* Update poem section to reflect new guidelines

New guidelines for poems

* Poetry, song lyrics or any content written in verse, where lines of text must be preserved just as they are in the source material, is required to be marked up with ```<div class="verse">```.
* Each group of lines of text must be contained in a separate ```<p class="linegroup">``` element and each line of text must be marked up with ```<span class="line">```. HTML line breaks, ```<br/>```, must be added between consecutive lines within a line group. Indented lines may be marked up using ```<span class="line_indent">``` or ```<span class="line_longindent">.```
*Line numbers must only be included if specific instructions are given about it, even if they are present in the source material. If line numbers are to be included, they must be marked up with ```<span class="linenum">```.
* If the content written in verse has a title it may be handled as a normal heading, with ```<section>``` elements wrapping the content. However, if it does not make sense to use a heading, it may be marked up with ```<p class="verse-title">``` and placed within the ```<div class="verse">``` container. This option must not be used unless specific instructions are given by the Ordering Agency.
* If there is an author name placed under the verse it may be marked up with ```<p class="verse-author">``` and placed at the end of the ```<div class="verse">``` container.


Best regards
Daniel