### PR TITLE
Allow pagebreaks content

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -331,6 +331,8 @@
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'pagebreak']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="tokenize(@class, '\s+') = ('page-front', 'page-normal', 'page-special')">[nordic105] Page breaks must have either a 'page-front', a 'page-normal' or a 'page-special' class. <value-of select="$context"/></assert>
+            <assert test="count(node() except text()) = 0">[nordic105b] Pagebreaks must not contain anything other than a text node. <value-of select="$context"/></assert>
+            <assert test="normalize-space(.) = string(.)">[nordic105c] The text content of a pagebreak must not contain unneccessary whitespaces. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -327,15 +327,10 @@
 
     <pattern id="epub_nordic_105">
         <title>Rule 105</title>
-        <p>Pagebreaks must have a page-* class and must not contain anything</p>
+        <p>Pagebreaks must have a correct class</p>
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'pagebreak']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="tokenize(@class, '\s+') = ('page-front', 'page-normal', 'page-special')">[nordic105] Page breaks must have either a 'page-front', a 'page-normal' or a 'page-special' class. <value-of select="$context"/></assert>
-            <assert test="count(* | comment()) = 0 and string-length(string-join(text(), '')) = 0">[nordic105] Pagebreaks must not contain anything<value-of select="
-                    if (string-length(text()) &gt; 0 and normalize-space(text()) = '') then
-                        ' (element contains empty spaces)'
-                    else
-                        ''"/>. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Hi @josteinaj 

I asked about page breaks and content within. The new example contains a lot of content in page breaks.

"About pagination, the guidelines have empty elements as default, but page numbers as content must be accepted by the validator as it is an important feature for some of the Ordering Agencies." - @AndersEkl

Best regards
Daniel