### PR TITLE
More fixes from examples.

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -704,16 +704,14 @@
                 <group>
                     <!-- content document -->
                     <ref name="attrs"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @epub:type, @class -->
-                    <oneOrMore>
-                       <element name="section">
-                           <choice>
-                               <ref name="cover"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, section -->
-                               <ref name="frontmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                               <ref name="bodymatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, h1, p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                               <ref name="backmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
-                           </choice>
-                       </element>
-                   </oneOrMore>
+                    <element name="section">
+                        <choice>
+                           <ref name="cover"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, section -->
+                           <ref name="frontmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
+                           <ref name="bodymatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, h1, p, hr, ol, ul, dl, pre, div, blockquote, img, figure, section, span, table, address, aside, math, article -->
+                           <ref name="backmatter"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, div, h1, p, hr, ol, ul, dl, pre, blockquote, img, figure, section, span, table, address, aside, math, article -->
+                        </choice>
+                    </element>
                 </group>
                 <group>
                     <!-- navigation document -->

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -220,7 +220,27 @@
             </list>
         </attribute>
     </define>
-    
+
+    <define name="attr.role">
+        <attribute name="role">
+            <list>
+                <ref name="roles"/>
+            </list>
+        </attribute>
+    </define>
+
+    <define name="attr.aria.label">
+        <attribute name="aria-label">
+            <ref name="Text"/>
+        </attribute>
+    </define>
+
+    <define name="attr.aria.labelledby">
+        <attribute name="aria-labelledby">
+            <ref name="Text"/>
+        </attribute>
+    </define>
+
     <define name="coreattrs.base">
         <optional>
             <ref name="attr.id"/> <!-- @id -->
@@ -230,6 +250,15 @@
         </optional>
         <optional>
             <ref name="attr.xmlspace"/> <!-- @xml:space -->
+        </optional>
+        <optional>
+            <ref name="attr.role"/> <!-- @role -->
+        </optional>
+        <optional>
+            <ref name="attr.aria.label"/> <!-- @aria-label -->
+        </optional>
+        <optional>
+            <ref name="attr.aria.labelledby"/> <!-- @aria-labelledby -->
         </optional>
     </define>
 
@@ -345,6 +374,15 @@
         </optional>
         <optional>
             <ref name="attr.xmlspace"/> <!-- @xml:space -->
+        </optional>
+        <optional>
+            <ref name="attr.role"/> <!-- @role -->
+        </optional>
+        <optional>
+            <ref name="attr.aria.label"/> <!-- @aria-label -->
+        </optional>
+        <optional>
+            <ref name="attr.aria.labelledby"/> <!-- @aria-labelledby -->
         </optional>
         <ref name="i18n"/> <!-- @xml:lang, @lang, @dir -->
         <!-- the showin attribute in DTBook maps to the following classes in HTML: showin-xxx, showin-xxp, showin-xlx, showin-xlp, showin-bxx, showin-bxp, showin-blx, showin-blp -->
@@ -664,21 +702,8 @@
             <!-- Strict content model: (h1 p)? (section | article) -->
             <choice>
                 <group>
-                    <a:documentation>single-page HTML.</a:documentation>
-                    <!-- single-page HTML -->
+                    <!-- content document -->
                     <ref name="attrs"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @epub:type, @class -->
-                    <element name="header">
-                        <a:documentation>h1</a:documentation>
-                        <ref name="doctitle.headline"/> <!-- h1 -->
-                        <optional>
-                            <a:documentation>p</a:documentation>
-                            <ref name="covertitle"/> <!-- p -->
-                        </optional>
-                        <zeroOrMore>
-                            <a:documentation>p</a:documentation>
-                            <ref name="docauthor"/> <!-- p -->
-                        </zeroOrMore>
-                    </element>
                     <oneOrMore>
                        <element name="section">
                            <choice>
@@ -2599,6 +2624,9 @@
         <a:documentation>   The title attribute must be used to describe the page number.</a:documentation>
         <element name="div">
             <ref name="attlist.pagebreak"/> <!-- @epub:type, @class, @id, @title, @xml:space, @xml:lang, @lang, @dir -->
+            <optional>
+                <ref name="Text"/>
+            </optional>
         </element>
     </define>
 
@@ -4354,6 +4382,52 @@
                 <value>question</value>
                 <value>referrer</value>
                 <value>true-false-problem</value>
+            </choice>
+        </zeroOrMore>
+    </define>
+
+    <define name="roles">
+        <zeroOrMore>
+            <choice>
+                <value>doc-abstract</value>
+                <value>doc-acknowledgements</value>
+                <value>doc-afterword</value>
+                <value>doc-appendix</value>
+                <value>doc-backlink</value>
+                <value>doc-biblioentry</value>
+                <value>doc-bibliography</value>
+                <value>doc-biblioref</value>
+                <value>doc-chapter</value>
+                <value>doc-colophon</value>
+                <value>doc-conclusion</value>
+                <value>doc-cover</value>
+                <value>doc-credit</value>
+                <value>doc-credits</value>
+                <value>doc-dedication</value>
+                <value>doc-endnote</value>
+                <value>doc-endnotes</value>
+                <value>doc-epigraph</value>
+                <value>doc-epilogue</value>
+                <value>doc-errata</value>
+                <value>doc-example</value>
+                <value>doc-footnote</value>
+                <value>doc-foreword</value>
+                <value>doc-glossary</value>
+                <value>doc-glossref</value>
+                <value>doc-index</value>
+                <value>doc-introduction</value>
+                <value>doc-noteref</value>
+                <value>doc-notice</value>
+                <value>doc-pagebreak</value>
+                <value>doc-pagelist</value>
+                <value>doc-part</value>
+                <value>doc-preface</value>
+                <value>doc-prologue</value>
+                <value>doc-pullquote</value>
+                <value>doc-qna</value>
+                <value>doc-subtitle</value>
+                <value>doc-tip</value>
+                <value>doc-toc</value>
             </choice>
         </zeroOrMore>
     </define>

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -241,6 +241,12 @@
         </attribute>
     </define>
 
+    <define name="attr.aria.describedby">
+        <attribute name="aria-describedby">
+            <ref name="Text"/>
+        </attribute>
+    </define>
+
     <define name="coreattrs.base">
         <optional>
             <ref name="attr.id"/> <!-- @id -->
@@ -259,6 +265,9 @@
         </optional>
         <optional>
             <ref name="attr.aria.labelledby"/> <!-- @aria-labelledby -->
+        </optional>
+        <optional>
+            <ref name="attr.aria.describedby"/> <!-- @aria-describedby -->
         </optional>
     </define>
 
@@ -384,6 +393,10 @@
         <optional>
             <ref name="attr.aria.labelledby"/> <!-- @aria-labelledby -->
         </optional>
+        <optional>
+            <ref name="attr.aria.describedby"/> <!-- @aria-describedby -->
+        </optional>
+
         <ref name="i18n"/> <!-- @xml:lang, @lang, @dir -->
         <!-- the showin attribute in DTBook maps to the following classes in HTML: showin-xxx, showin-xxp, showin-xlx, showin-xlp, showin-bxx, showin-bxp, showin-blx, showin-blp -->
     </define>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
@@ -25,7 +25,7 @@
         <p></p>
         <rule context="opf:package">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="@version = '3.2'">[opf2] the version attribute must be 3.2</assert>
+            <assert test="@version = '3.0'">[opf2] the version attribute must be 3.0</assert>
             <assert test="@unique-identifier = 'pub-identifier'">[opf2] on the package element; the unique-identifier-attribute must be present and equal 'pub-identifier'</assert>
             <assert test="namespace-uri-for-prefix('dc',.) = 'http://purl.org/dc/elements/1.1/'">[opf2] on the package element; the dublin core namespace (xmlns:dc="http://purl.org/dc/elements/1.1/")
                 must be declared on the package element</assert>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -331,11 +331,6 @@
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'pagebreak']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="tokenize(@class, '\s+') = ('page-front', 'page-normal', 'page-special')">[nordic105] Page breaks must have either a 'page-front', a 'page-normal' or a 'page-special' class. <value-of select="$context"/></assert>
-            <assert test="count(* | comment()) = 0 and string-length(string-join(text(), '')) = 0">[nordic105] Pagebreaks must not contain anything<value-of select="
-                    if (string-length(text()) &gt; 0 and normalize-space(text()) = '') then
-                        ' (element contains empty spaces)'
-                    else
-                        ''"/>. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 
@@ -683,7 +678,7 @@
     <pattern id="epub_nordic_261">
         <title>Rule 261</title>
         <p>Text can't be direct child of div</p>
-        <rule context="html:div">
+        <rule context="html:div[not(tokenize(@epub:type, '\s+') = 'pagebreak')]">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <report test="text()[normalize-space(.)]">[nordic261] Text can't be placed directly inside div elements. Try wrapping it in a p element. <value-of select="concat('(', normalize-space(string-join(text(), ' ')), ')')"/> <value-of select="$context"/></report>
         </rule>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -331,6 +331,7 @@
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'pagebreak']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="tokenize(@class, '\s+') = ('page-front', 'page-normal', 'page-special')">[nordic105] Page breaks must have either a 'page-front', a 'page-normal' or a 'page-special' class. <value-of select="$context"/></assert>
+            <assert test="count(* | comment()) = 0 and text() = normalize-space(text())">[nordic105] Pagebreaks must not contain elements or comments. Text content, if present, must not contain extra whitespace. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Hi @josteinaj 

This package of fixes contains:

* Allow role, aria-label and aria-labelledby
* remove DTBook legacy docauthor and doctitle "The validator still seems to expect a single-page structure. I think this is in the RelaxNG file." - @martinpub 
* revert version to 3.0. "This is incorrect, it should be 3.0 also for EPUB 3.2, see https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-elem." - @martinpub 
* Allow text in page breaks

The above change where we remove the header block is what I interpreted @martinpub's comment above. I understand that we don't want this legacy in the code when it's not specified in the documentation but I'm not familiar with the "single-page structure" so I did not know exactly what was required by this comment.

Best regards
Daniel