### PR TITLE
After review of DTB37628-corrected and DTB38033-corrected

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -85,10 +85,27 @@
             <ref name="sidebar"/> <!-- aside, figure -->
             <ref name="note"/> <!-- aside -->
             <ref name="annotation"/> <!-- aside -->
+            <ref name="general.aside"/> <!-- aside -->
         </choice>
         <!-- block elements unique to html without imggroup. -->
     </define>
-    
+
+    <define name="general.aside">
+        <element name="aside">
+            <!-- HTML content model: (a | abbr | address | article | aside | audio | b | bdi | bdo | blockquote | br | button | canvas | cite | code | data | datalist | del | details | dfn | dialog | div | dl | em | embed | fieldset | figure | footer | form | h1 | h2 | h3 | h4 | h5 | h6 | header | hr | i | iframe | img | input | ins | kbd | keygen | label | link | main | map | mark | math | menu | meta | meter | nav | noscript | object | ol | output | p | pre | progress | q | ruby | s | samp | script | section | select | small | span | strong | style | sub | sup | svg | table | template | textarea | time | u | ul | var | video | wbr | (text))* -->
+            <!-- Strict content model: (h1 | em | strong | dfn | code | samp | kbd | abbr | a | img | figure | br | q | sub | sup | span | bdo | p | ol | ul | dl | div | blockquote | table | address | (text))* -->
+            <ref name="attrs"/> <!-- @epub:type, @class, @id, @title, @xml:space, @xml:lang, @lang, @dir -->
+            <zeroOrMore>
+                <choice>
+                    <ref name="hd"/> <!-- h1, h2, h3, h4, h5, h6 -->
+                    <ref name="flow"/> <!-- em, strong, dfn, code, samp, kbd, span, abbr, math, a, img, br, q, sub, sup, bdo, p, hr, ol, ul, dl, pre, div, blockquote, section, table, address, aside, figure -->
+                    <ref name="pagebreak.block"/> <!-- div -->
+                </choice>
+            </zeroOrMore>
+            <ref name="flow"/> <!-- em, strong, dfn, code, samp, kbd, span, abbr, math, a, img, br, q, sub, sup, bdo, p, hr, ol, ul, dl, pre, div, blockquote, section, table, address, aside, figure -->
+        </element>
+    </define>
+
     <define name="inlineinblock">
         <a:documentation>inlines that may alternatively be in block elements.</a:documentation>
         <choice>
@@ -2158,8 +2175,10 @@
                 <value>linegroup</value>
             </attribute>
             <oneOrMore>
-                <ref name="poem.line"/>
-                <ref name="poem.linenum"/>
+                <choice>
+                    <ref name="poem.line"/>
+                    <ref name="poem.linenum"/>
+                </choice>
             </oneOrMore>
         </element>
     </define>
@@ -2169,9 +2188,11 @@
             <attribute name="class">
                 <list>
                     <oneOrMore>
-                        <value>line</value>
-                        <value>line_indent</value>
-                        <value>line_longindent</value>
+                        <choice>
+                            <value>line</value>
+                            <value>line_indent</value>
+                            <value>line_longindent</value>
+                        </choice>
                     </oneOrMore>
                 </list>
             </attribute>
@@ -2179,7 +2200,9 @@
                 <ref name="inline"/> <!-- em, strong, dfn, code, samp, kbd, span, abbr, math, a, img, br, q, sub, sup, bdo -->
             </zeroOrMore>
         </element>
-        <ref name="br" />
+        <optional>
+            <ref name="br" />
+        </optional>
     </define>
 
     <define name="poem.linenum">
@@ -4134,7 +4157,7 @@
                 <value>z3998:article</value>
                 <value>z3998:aside</value>
                 <value>z3998:attribution</value>
-                <!--<value>z3998:author</value>-->
+                <value>z3998:author</value>
                 <value>z3998:award</value>
                 <!--<value>z3998:backmatter</value>-->
                 <value>z3998:bcc</value>

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -766,7 +766,7 @@
                 <ref name="types"/>
             </list>
         </attribute>
-        <ref name="attrsrqd.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
+        <ref name="attrs.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
         <zeroOrMore>
             <element name="section">
                 <attribute name="class">
@@ -995,7 +995,7 @@
     </define>
 
     <define name="attlist.level1" combine="interleave">
-        <ref name="attrsrqd.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
+        <ref name="attrs.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
     </define>
     
     <define name="level1.only-headline">
@@ -1388,6 +1388,7 @@
 
     <define name="htmlinlinenoa">
         <choice>
+            <ref name="lic"/>
             <ref name="sent"/> <!-- span -->
             <ref name="w"/> <!-- span -->
             <ref name="pagebreak.inline"/> <!-- span -->
@@ -3085,13 +3086,6 @@
     </define>
 
     <define name="attlist.docauthor" combine="interleave">
-        <attribute name="epub:type">
-            <list>
-                <ref name="types"/>
-                <value>z3998:author</value>
-                <ref name="types"/>
-            </list>
-        </attribute>
         <attribute name="class">
             <list>
                 <ref name="classes"/>
@@ -3099,7 +3093,7 @@
                 <ref name="classes"/>
             </list>
         </attribute>
-        <ref name="attrs.base"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir -->
+        <ref name="attrs.noclass"/> <!-- @id, @epub:type, @title, @xml:space, @xml:lang, @lang, @dir -->
     </define>
     
     <define name="covertitle">
@@ -4473,7 +4467,6 @@
                     <value>rightflap</value>
                     <value>line</value>
                     <value>linenum</value>
-                    <value>title</value>
                     <value>prodnote</value>
                     <value>sidebar</value>
                     <value>annotation</value>
@@ -4498,7 +4491,6 @@
                     <value>fig-desc</value>
                     <value>emptyline</value>
                     <value>separator</value>
-                    <value>title</value>
                     <value>docauthor</value>
                     <value>bridgehead</value>
                     <value>lic</value>

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -716,7 +716,7 @@
             <choice>
                 <group>
                     <!-- content document -->
-                    <ref name="attrs"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @epub:type, @class -->
+                    <ref name="attrs.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
                     <element name="section">
                         <choice>
                            <ref name="cover"/> <!-- @epub:type, @id, @title, @xml:space, @xml:lang, @lang, @dir, @class, section -->
@@ -735,6 +735,13 @@
                             <attribute name="epub:type"/>
                             <optional>
                                 <attribute name="hidden"/>
+                            </optional>
+                            <ref name="attr.role"/>
+                            <optional>
+                                <ref name="attr.aria.label"/>
+                            </optional>
+                            <optional>
+                                <ref name="attr.aria.labelledby"/>
                             </optional>
                             <ref name="h1"/> <!-- h1 -->
                             <ref name="list"/> <!-- ol, ul -->
@@ -2230,7 +2237,10 @@
         
             "tabindex"=tabbing order.
       -->
-        <ref name="attrs"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @epub:type, @class -->
+        <ref name="attrs.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @epub:type, @class -->
+        <optional>
+            <attribute name="epub:type" />
+        </optional>
         <optional>
             <attribute name="type">
                 <ref name="ContentType"/>
@@ -4408,7 +4418,7 @@
         <zeroOrMore>
             <choice>
                 <value>doc-abstract</value>
-                <value>doc-acknowledgements</value>
+                <value>doc-acknowledgments</value>
                 <value>doc-afterword</value>
                 <value>doc-appendix</value>
                 <value>doc-backlink</value>
@@ -4446,6 +4456,7 @@
                 <value>doc-subtitle</value>
                 <value>doc-tip</value>
                 <value>doc-toc</value>
+                <value>navigation</value>
             </choice>
         </zeroOrMore>
     </define>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -136,7 +136,7 @@
         <rule context="html:a[tokenize(@epub:type,'\s+')='noteref']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <!-- this is the multi-HTML version of the rule; the single-HTML version of this rule is in nordic2015-1.sch -->
-            <assert test="count(//html:*[tokenize(@epub:type,'\s+')=('note','endnote','footnote') and @id = current()/substring-after(@href,'#')]) &gt;= 1">[nordic_opf_and_html_26b] The note
+            <assert test="count(//html:*[tokenize(@role,'\s+')=('doc-endnote','doc-footnote') and @id = current()/substring-after(@href,'#')]) &gt;= 1">[nordic_opf_and_html_26b] The note
                 reference with the href "<value-of select="@href"/>" attribute must resolve to a note, endnote or footnote in the publication: <value-of select="$context"/> (in <value-of select="replace(base-uri(),'.*/','')"
                 />)</assert>
         </rule>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
@@ -34,7 +34,8 @@
             <assert test="matches(@prefix, '(^|\s)a11y:\s+http://www.idpf.org/epub/vocab/package/a11y/#(\s|$)') or not(opf:meta[starts-with(@property, 'a11y:')])">[opf2] on the package element; the prefix attribute must declare the a11y metadata namespace using the correct URI (prefix="a11y:
                 http://www.idpf.org/epub/vocab/package/a11y/#")</assert>
         </rule>
-        <rule context="opf:meta[boolean(@property) and contains(@property, ':') and not(substring-before(@property, ':') = ('dc', 'dcterms'))]">
+
+        <rule context="opf:meta[boolean(@property) and contains(@property, ':') and not(substring-before(@property, ':') = ('dc', 'dcterms', 'a11y', 'schema', 'marc', 'media', 'onix', 'rendition', 'xsd'))]">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <let name="prefix" value="substring-before(@property, ':')"/>
             <assert test="matches(string(ancestor::opf:package[1]/@prefix[1]), concat('(^|\s)', $prefix, ':(\s|$)'))">[opf2] on the package element; the prefix attribute must declare the '<value-of select="$prefix"/>' prefix</assert>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -887,7 +887,7 @@
         <p>Rearnotes should not be used. Use endnotes instead.</p>
         <rule context="*">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <report test="tokenize(@epub:type, '\s+') = ('rearnote', 'rearnotes')">[nordic290] Rearnotes are deprecated. Endnotes are required to be used instead. <value-of select="$context"/></report>
+            <assert test="tokenize(@epub:type, '\s+') = ('rearnote', 'rearnotes')">[nordic290] Rearnotes are deprecated. Endnotes are required to be used instead. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -518,7 +518,7 @@
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'footnote']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="(parent::html:section)">[nordic204a] 'footnote' must have a parent section. <value-of select="$context"/></assert>
-            <assert test="not(following-sibling::html:*[not(local-name()='aside' and @epub-type='footnote')])">[nordic204a] 'footnote' must be placed at the end of a section.</assert>
+            <assert test="not(following-sibling::html:*[not(local-name()='aside' and @epub:type='footnote')])">[nordic204a] 'footnote' must be placed at the end of a section.</assert>
         </rule>
     </pattern>
 
@@ -704,15 +704,6 @@
         </rule>
     </pattern>
 
-    <pattern id="epub_nordic_266">
-        <title>Rule 266</title>
-        <p></p>
-        <rule context="html:*[*[tokenize(@epub:type, '\s+') = 'footnote']]">
-            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="self::html:aside">[nordic266] Footnotes must be wrapped in an "aside" element, but is currently wrapped in a <name/>. <value-of select="$context"/></assert>
-        </rule>
-    </pattern>
-
     <pattern id="epub_nordic_267_a">
         <title>Rule 267a</title>
         <p></p>
@@ -887,7 +878,7 @@
         <p>Rearnotes should not be used. Use endnotes instead.</p>
         <rule context="*">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="tokenize(@epub:type, '\s+') = ('rearnote', 'rearnotes')">[nordic290] Rearnotes are deprecated. Endnotes are required to be used instead. <value-of select="$context"/></assert>
+            <assert test="not(tokenize(@epub:type, '\s+') = ('rearnote', 'rearnotes'))">[nordic290] Rearnotes are deprecated. Endnotes are required to be used instead. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 
@@ -896,8 +887,8 @@
         <p>Backmatter sections require specific roles</p>
         <rule context="html:section[tokenize(@epub:type, '\s+') = 'backmatter']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="tokenize(@role, '\s+') = ('doc-afterword', 'doc-appendix', 'doc-colophon', 'doc-conclusion', 'doc-dedication', 'doc-epigraph', 'doc-epilogue')">
-                [nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue) <value-of select="$context"/>
+            <assert test="tokenize(@role, '\s+') = ('doc-afterword', 'doc-appendix', 'doc-colophon', 'doc-conclusion', 'doc-dedication', 'doc-epigraph', 'doc-epilogue', 'doc-glossary', 'doc-index')">
+                [nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue, doc-glossary, doc-index) <value-of select="$context"/>
             </assert>
         </rule>
     </pattern>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -891,4 +891,14 @@
         </rule>
     </pattern>
 
+    <pattern id="epub_nordic_291">
+        <title>Rule 290</title>
+        <p>Backmatter sections require specific roles</p>
+        <rule context="html:section[tokenize(@epub:type, '\s+') = 'backmatter']">
+            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
+            <assert test="tokenize(@role, '\s+') = ('doc-afterword', 'doc-appendix', 'doc-colophon', 'doc-conclusion', 'doc-dedication', 'doc-epigraph', 'doc-epilogue')">
+                [nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue) <value-of select="$context"/>
+            </assert>
+        </rule>
+    </pattern>
 </schema>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -518,7 +518,7 @@
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'footnote']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="(parent::html:section)">[nordic204a] 'footnote' must have a parent section. <value-of select="$context"/></assert>
-            <assert test="not(following-sibling::html:*[not(local-name()='aside' and @epub:type='footnote')])">[nordic204a] 'footnote' must be placed at the end of a section.</assert>
+            <assert test="not(following-sibling::html:*[not(local-name()='aside' and tokenize(@epub:type, '\s+')='footnote')])">[nordic204a] 'footnote' must be placed at the end of a section.</assert>
         </rule>
     </pattern>
 
@@ -885,10 +885,10 @@
     <pattern id="epub_nordic_291">
         <title>Rule 290</title>
         <p>Backmatter sections require specific roles</p>
-        <rule context="html:section[tokenize(@epub:type, '\s+') = 'backmatter']">
+        <rule context="html:section[tokenize(@epub:type, '\s+') = 'backmatter' and @role]">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="tokenize(@role, '\s+') = ('doc-afterword', 'doc-appendix', 'doc-colophon', 'doc-conclusion', 'doc-dedication', 'doc-epigraph', 'doc-epilogue', 'doc-glossary', 'doc-index')">
-                [nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue, doc-glossary, doc-index) <value-of select="$context"/>
+            <assert test="tokenize(@role, '\s+') = ('doc-afterword', 'doc-appendix', 'doc-bibliography', 'doc-colophon', 'doc-conclusion', 'doc-dedication', 'doc-endnotes', 'doc-epigraph', 'doc-epilogue', 'doc-glossary', 'doc-index')">
+                [nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-bibliography, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue, doc-glossary, doc-index) <value-of select="$context"/>
             </assert>
         </rule>
     </pattern>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -331,7 +331,7 @@
         <rule context="html:*[tokenize(@epub:type, '\s+') = 'pagebreak']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="tokenize(@class, '\s+') = ('page-front', 'page-normal', 'page-special')">[nordic105] Page breaks must have either a 'page-front', a 'page-normal' or a 'page-special' class. <value-of select="$context"/></assert>
-            <assert test="count(* | comment()) = 0 and text() = normalize-space(text())">[nordic105] Pagebreaks must not contain elements or comments. Text content, if present, must not contain extra whitespace. <value-of select="$context"/></assert>
+            <assert test="count(* | comment()) = 0 and ( not(text()) or text() = normalize-space(text()) )">[nordic105] Pagebreaks must not contain elements or comments. Text content, if present, must not contain extra whitespace. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Hi @josteinaj 

This PR now has the changes required for the latest report of DTB38033.

* If there is no text at all the validation fails.
* Allow ```role```, ```aria-label```, and ```aria-labelled``` by in navigation documents
* Added navigation to roles (used in landmarks)
* Allow any ```epub:type``` on anchors (required for landmarks as they are navigation types)
* ```epub:type``` is no longer required for endnotes to changed to fetch them with role for ```nordic_opf_and_html_26b```
* New rule "[nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue)"
* Changed a report message for deprecation to assert instead 
* >Why was this highlighted in green for DTB38033? I.e. it got the class "success" instead of "error", probably a bug.
* ```lic``` is now allowed inside of anchor tags
* Don't require ```epub:type``` for level1 sections
* Don't require ```epub:type="z3998:author"``` on docauthor elements
* Removed special handling of title headings
* Bug fixes for footnotes and rearnotes
* Removed rule [nordic266] requiring footnotes to be wrapped with aside.
* New rule "[nordic291] Backmatter can only use roles (doc-afterword, doc-appendix, doc-colophon, doc-conclusion, doc-dedication, doc-epigraph, doc-epilogue, doc-glossary, doc-index)"
* Adding support for general asides
* Fixing issues with poem structure
* Allowing epub type for z3998:author in epub types
* Adding more prefixes that are default and need not be specified.
* Allowing backmatter sections without roles, and accepting a few more correct roles.


Best regards
Daniel