### PR TITLE
Require section id for all sections.

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -1012,7 +1012,7 @@
     </define>
 
     <define name="attlist.level1" combine="interleave">
-        <ref name="attrs.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
+        <ref name="attrsrqd.notype"/> <!-- @id, @title, @xml:space, @xml:lang, @lang, @dir, @class -->
     </define>
     
     <define name="level1.only-headline">


### PR DESCRIPTION
Hi @josteinaj 

I found that we had many issues with links, and I think one thing I overlooked in the last PR was that ID is required for sections in the specification.

Best regards
Daniel