### PR TITLE
Allow the same ID on landmarks as in toc.

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -4340,7 +4340,7 @@
                 <value>z3998:presentation</value>
                 <value>z3998:primary</value>
                 <value>z3998:product</value>
-                <!--<value>z3998:production</value>-->
+                <value>z3998:production</value>
                 <!--<value>z3998:prologue</value>-->
                 <value>z3998:promotional-copy</value>
                 <value>z3998:published-works</value>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
@@ -138,7 +138,7 @@
         <p>navdoc references must all be unique</p>
         <rule context="html:a">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="not(@href = preceding::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
+            <assert test="not(@href = preceding-sibling::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
@@ -138,11 +138,11 @@
         <p>navdoc references must all be unique</p>
         <rule context="html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='toc']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="not(@href = preceding::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
+            <assert test="not(@href = preceding::html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='toc']/@href)">[nordic_nav_ncx_5] Two references in the toc of the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
         </rule>
         <rule context="html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='landmarks']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="not(@href = preceding::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
+            <assert test="not(@href = preceding::html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='landmarks']/@href)">[nordic_nav_ncx_5] Two references among the landmarks in navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
@@ -138,11 +138,11 @@
         <p>navdoc references must all be unique</p>
         <rule context="html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='toc']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="not(@href = preceding-sibling::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
+            <assert test="not(@href = preceding::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
         </rule>
         <rule context="html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='landmarks']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="not(@href = preceding-sibling::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
+            <assert test="not(@href = preceding::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-ncx.sch
@@ -136,7 +136,11 @@
     <pattern>
         <title>nordic_nav_ncx_5</title>
         <p>navdoc references must all be unique</p>
-        <rule context="html:a">
+        <rule context="html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='toc']">
+            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
+            <assert test="not(@href = preceding-sibling::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
+        </rule>
+        <rule context="html:a[ancestor::html:nav/tokenize(@epub:type,'\s+')='landmarks']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="not(@href = preceding-sibling::html:a/@href)">[nordic_nav_ncx_5] Two references in the navigation document can not point to the same location in the content. <value-of select="$context"/></assert>
         </rule>


### PR DESCRIPTION
Hi @josteinaj 

This is a fix that I've done because @AndersEkl suggested it by email.

"And the landmarks should be allowed to reference the same id values as items in the toc as they literally point to the same places."

If you and @martinpub think this is reasonable, this is a small change.

Best regards
Daniel