### PR TITLE
Removing either.

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-references.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-references.sch
@@ -115,7 +115,7 @@
             <let name="fragment" value="substring-after(@href,'#')"/>
             <let name="result-ref" value="/*/c:result/c:result[(@data-sectioning-id) = $fragment]"/>
 
-            <assert test="$result-ref">[nordic_nav_references_2a] All references from the navigation document must reference either a sectioning element in one of the content documents:
+            <assert test="$result-ref">[nordic_nav_references_2a] All references from the navigation document must reference a sectioning element in one of the content documents:
                     <value-of select="$context"/></assert>
             <report test="count($result-ref) &gt; 1">[nordic_nav_references_2a] All references from the navigation document must reference exactly one sectioning element in one of the
                 content documents, there are multiple sections matching the href="<value-of select="@href"/>" in <value-of select="$context"/>; <value-of


### PR DESCRIPTION
Hi @martinpub 

This test checks that each sectioning element has a reference, not that it's unique. The next rule does that testing. So I thought it was reasonable to only remove the word either from the message.

Best regards
Daniel