### PR TITLE
Require headings to be equal to toc. 

### DIFF
--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-references.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-references.sch
@@ -100,7 +100,7 @@
                 /> "<value-of select="@data-sectioning-element"/>" element<value-of select="if (@data-sectioning-id) then concat(' with id=&quot;', @data-sectioning-id,'&quot;') else ''"/> is
                     <value-of select="if (count($nav-ref)=0) then 'not referenced' else 'referenced multiple times'"/> from the navigation document.</assert>
 
-            <assert test="count($nav-ref) = 0 or not(@data-heading-id) or normalize-space(string-join(.//text(),'')) = normalize-space(string-join($nav-ref//text(),''))">[nordic_nav_references_1] The
+            <assert test="count($nav-ref) = 0 or normalize-space(string-join(.//text(),'')) = normalize-space(string-join($nav-ref//text(),''))">[nordic_nav_references_1] The
                 text for the heading in the navigation document ("<value-of select="normalize-space(string-join($nav-ref//text(),''))"/>") should match the headline in the content document ("<value-of
                     select="normalize-space(string-join(.//text(),''))"/>" at <value-of select="($heading-ref, $sectioning-ref)[1]"/>)</assert>
         </rule>

--- a/src/main/resources/xml/xslt/2020-1/list-heading-and-pagebreak-references.xsl
+++ b/src/main/resources/xml/xslt/2020-1/list-heading-and-pagebreak-references.xsl
@@ -47,6 +47,7 @@
                     <xsl:attribute name="data-sectioning-id" select="@id"/>
                 </xsl:if>
                 <xsl:attribute name="data-sectioning-depth" select="count(ancestor-or-self::section | ancestor-or-self::article)"/>
+                <xsl:value-of select="normalize-space(@aria-label)"/>
             </c:result>
         </xsl:if>
         <xsl:apply-templates/>


### PR DESCRIPTION
Hi @martinpub 

Require headings to be equal to toc. 
If there is no H[x] there should be an aria-label with the correct information.

This should solve #463.

Best regards
Daniel