### PR TITLE
Switch to newer epubcheck and modules parent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>modules-parent</artifactId>
-        <version>1.13.7</version>
+        <version>1.14.1</version>
         <!--<relativePath>../../../parent/</relativePath>-->
     </parent>
     
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.w3c</groupId>
             <artifactId>epubcheck</artifactId>
-            <version>4.2.0</version>
+            <version>4.2.5</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/xml/xproc/step/2015-1/epub3-validate.step.xpl
+++ b/src/main/resources/xml/xproc/step/2015-1/epub3-validate.step.xpl
@@ -2,7 +2,7 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:d="http://www.daisy.org/ns/pipeline/data"
     type="px:nordic-epub3-validate.step" name="main" version="1.0" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:opf="http://www.idpf.org/2007/opf"
     xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dtb="http://www.daisy.org/z3986/2005/dtbook/" xmlns:jhove="http://hul.harvard.edu/ois/xml/ns/jhove">
+    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dtb="http://www.daisy.org/z3986/2005/dtbook/" xmlns:jhove="http://schema.openpreservation.org/ois/xml/ns/jhove">
 
     <p:serialization port="report.out" indent="true"/>
 

--- a/src/main/resources/xml/xproc/step/2020-1/epub3-validate.step.xpl
+++ b/src/main/resources/xml/xproc/step/2020-1/epub3-validate.step.xpl
@@ -10,7 +10,7 @@
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns:dcterms="http://purl.org/dc/terms/"
                 xmlns:dtb="http://www.daisy.org/z3986/2005/dtbook/"
-                xmlns:jhove="http://hul.harvard.edu/ois/xml/ns/jhove"
+                xmlns:jhove="http://schema.openpreservation.org/ois/xml/ns/jhove"
                 type="px:nordic-epub3-validate.step.2020-1"
                 name="main"
                 version="1.0">

--- a/src/main/resources/xml/xslt/epubcheck-report-to-pipeline-report.xsl
+++ b/src/main/resources/xml/xslt/epubcheck-report-to-pipeline-report.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all" version="2.0"
-    xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xpath-default-namespace="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:d="http://www.daisy.org/ns/pipeline/data">
+    xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove" xpath-default-namespace="http://schema.openpreservation.org/ois/xml/ns/jhove" xmlns:d="http://www.daisy.org/ns/pipeline/data">
 
     <xsl:output indent="yes"/>
 


### PR DESCRIPTION
Hi @martinpub 

This will solve the issue we had with not creating a correct XML document. This was because we have updated to the latest EPUBCheck in the pipeline. 

I've updated to the latest EPUBCheck and the next to the latest version of the parent modules. Lastly, I've updated some namespaces to their new domains.

We are not changing to using the last version yet of pipeline modules because it will break the tests. The last version of the pipeline will not create valid EPUBs following the nordic guidelines. This could be good to keep in mind if you want to convert DTBooks to EPUB.

Best regards
Daniel