### PR TITLE
Add an editor config, a mvn goal and a ci action to check code conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig: maintain consistent coding styles for multiple
+# developers working on the same project across various editors and
+# IDEs, see https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset and 4 space indentation for all xml, xslt, xpl,
+# xprocspec and xspec files
+[*.{xml,xpl,xsl,xprocspec,xspec}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+
+

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,17 @@
+name: Check code conventions
+
+on: [push]
+
+jobs:
+  check-code-conventions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build with Maven
+        run: mvn --batch-mode editorconfig:check

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ The nordic migrator can be built with Maven,
 either directly (with for instance `mvn clean package`),
 or indirectly with Docker (with for instance `docker build .`).
 
+To check the code conventions use a special Maven plugin: `mvn
+editorconfig:check`. The conventions are defined in `.editorconfig`
+which is picked up by most editors, see https://editorconfig.org/. You
+can also fix the conventions in all files with `mvn
+editorconfig:format`.
+
 Releasing
 ---------
 

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
                 <executions>
                     <execution>
                         <id>check</id>
-                        <phase>verify</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.ec4j.maven</groupId>
+                <artifactId>editorconfig-maven-plugin</artifactId>
+                <version>0.1.1</version>
+                <executions>
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+		      <!-- You can exclude further files from processing: -->
+                      <exclude>src/test/**/*.epub</exclude>
+                      <exclude>**/*.otf</exclude>
+                      <exclude>documentation/*.odg</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
This PR adds a cross editor config file, a Maven goal that uses the config to check the source code and finally a github action to check every commit for these conventions via maven.

Should fix at least in part #476.

When running the mvn goal quite a few files have problems. These can easily be fixed with `mvn editorconfig:format`. But I think such a global change should go in a separate PR.

