### PR TITLE
Updating Docker commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,10 +67,10 @@
           <h2>Using Docker (recommended)</h2>
           <p>The Nordic Migrator is published as <code>nlbdev/nordic-epub3-dtbook-migrator</code>, tagged with release versions.</p>
           <p>Example of how to run the Nordic EPUB3/DTBook Migrator with Docker:</p>
-          <pre><kbd>docker run --network=host --env PIPELINE2_WS_LOCALFS=false --rm -it nlbdev/nordic-epub3-dtbook-migrator:1.5.2</kbd></pre>
+          <pre><kbd>docker run --detach --pull always --name pipeline -e PIPELINE2_WS_HOST=0.0.0.0 -e PIPELINE2_WS_AUTHENTICATION=false nlbdev/nordic-epub3-dtbook-migrator:1.5.2</kbd></pre>
           
           <p>After starting the Nordic Migrator, you could also start the Pipeline 2 Web UI on the same system like this, if you don't have any other interface (starts on <a href="http://localhost:9000/">http://localhost:9000/</a>):</p>
-          <pre><kbd>docker run --network=host --rm -it daisyorg/pipeline-webui:v2.7.1</kbd></pre>
+          <pre><kbd>docker run --detach --pull always --link pipeline -p 9000:9000 --name pipeline-webui -v webui-data:/opt/daisy-pipeline2-webui/data -e DAISY_PIPELINE2_URL=http://pipeline:8181/ws daisyorg/pipeline-webui:v2.7.1</kbd></pre>
 
 	  <h3>Using docker-compose</h3>
 	  <p>A slightly more elaborate method of running the validator in Docker is using <a href="https://docs.docker.com/compose/"><kbd>docker-compose</kbd></a>.</p>


### PR DESCRIPTION
Hi @josteinaj, I updated to the Docker commands last known to work for me. Do you think the parameters are OK? I think the linking method was needed for proper exposure of web service on a Windows host. This is also one of the examples at the [DAISY Pipeline 2 web page](https://daisy.github.io/pipeline/Get-Help/User-Guide/Installation/).