### PR TITLE
Add repository links for some repositories that used http instead of https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,18 @@
         <developerConnection>scm:git:git@github.com:nlbdev/nordic-epub3-dtbook-migrator.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-    
+
+    <repositories>
+        <repository>
+            <id>internal-repository</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>restlet</id>
+            <url>https://maven.restlet.talend.com/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!--
             for XProcScriptService


### PR DESCRIPTION
Hi @josteinaj 

I have a newer version of maven that don't want to run the original test script because some of the repositories in Pipeline runs over HTTP. 

So this PR will add https versions of these repositories.

Best regards
Daniel