### PR TITLE
Fixing locale issue with running validator.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ RUN locale-gen
 RUN wget https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-x64.tar.xz
 RUN mkdir -p /usr/local/lib/nodejs && tar -xJf node-v16.18.0-linux-x64.tar.xz -C /usr/local/lib/nodejs && rm node-v16.18.0-linux-x64.tar.xz
 ENV PATH "/usr/local/lib/nodejs/node-v16.18.0-linux-x64/bin:$PATH"
+ENV LC_ALL "en_US.UTF-8"
+ENV LANG "en_US.UTF-8"
+ENV LANGUAGE "en_US.UTF-8"
 RUN npm install npm@8.12.2 --location=global
 RUN npm install multer@1.4.5-lts.1
 RUN npm install @daisy/ace --location=global

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,13 @@ RUN apt -y autoremove
 
 RUN rm /etc/apt/preferences.d/no-debian-php
 
-RUN apt -y install openjdk-11-jre libgbm-dev libxkbcommon-x11-0 libgtk-3-0 \
+RUN apt -y install openjdk-11-jre libgbm-dev libxkbcommon-x11-0 libgtk-3-0 locales \
         php7.4 libzip-dev unzip cron tzdata sudo locales gcc wget python3 && rm -rf /var/cache/apk/*
 RUN docker-php-ext-install zip
+
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+
+RUN locale-gen
 
 RUN wget https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-x64.tar.xz
 RUN mkdir -p /usr/local/lib/nodejs && tar -xJf node-v16.18.0-linux-x64.tar.xz -C /usr/local/lib/nodejs && rm node-v16.18.0-linux-x64.tar.xz
@@ -70,7 +74,7 @@ RUN chmod +x /root/cron_job.sh
 ADD web/prepare_env.sh /root/prepare_env.sh
 RUN chmod +x /root/prepare_env.sh
 
-RUN sed -i 's/^exec /\n\n\/root\/prepare_env.sh\n\nservice cron start\n\nexec /' /usr/local/bin/apache2-foreground
+RUN sed -i 's/^exec /\n\n\/root\/prepare_env.sh\n\nexport LANG=en_US.UTF-8\n\nservice cron start\n\nexec /' /usr/local/bin/apache2-foreground
 
 ADD web/bin/ /var/www/bin/
 ADD web/include/ /var/www/include/

--- a/client/src/main/java/org/daisy/validator/NordicValidator.java
+++ b/client/src/main/java/org/daisy/validator/NordicValidator.java
@@ -162,7 +162,6 @@ public class NordicValidator {
                 System.exit(1);
             }
             System.exit(0);
-            System.exit(0);
         } catch (Exception e) {
             logger.fatal(e.getMessage(), e);
             System.exit(1);


### PR DESCRIPTION
Hi @josteinaj 

We got a report from MTM that the validator was not running with UTF-8, so some errors were false positives due to Swedish text.

This PR will add a UTF-8 locale to the docker runner, so everything in Apache will run with UTF-8. 

I also fixed a minor typo where the exit function was called twice :)

Best regards
Daniel