### PR TITLE
Loosen the requirement of NCX file and change the issue reporting logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pom.xml.next
 dependency-reduced-pom.xml
 buildNumber.properties
 *~
+/.idea
+*.iml

--- a/client/src/main/java/org/daisy/validator/EPUBFiles.java
+++ b/client/src/main/java/org/daisy/validator/EPUBFiles.java
@@ -192,10 +192,8 @@ public class EPUBFiles {
         BufferedWriter bw;
         if (ncxFile == null || zipFile.getEntry(ncxFile) == null) {
             ncxFile = ncxFile == null ? "nav.ncx" : ncxFile;
-            errorList.add(new Issue("", "File missing", ncxFile, Guideline.NAV_NCX, Issue.ERROR_WARN));
         } else if (navFile == null || zipFile.getEntry(navFile) == null) {
             navFile = navFile == null ? "nav.xhtml" : navFile;
-            errorList.add(new Issue("", "File missing", navFile, Guideline.NAV_NCX, Issue.ERROR_WARN));
             errorList.add(new Issue("", "File missing", navFile, Guideline.NAV_REFERENCES, Issue.ERROR_WARN));
         } else {
             fos = new FileOutputStream(new File(epubDir, EPUB_REFERENCE_NAV_NCX_FILE));

--- a/client/src/main/java/org/daisy/validator/report/ReportGenerator.java
+++ b/client/src/main/java/org/daisy/validator/report/ReportGenerator.java
@@ -42,12 +42,7 @@ public class ReportGenerator {
 
         String errorStatus = "SUCCESS";
         if (issueList.size() > 0) {
-            for (Issue i : issueList) {
-                if (i.getErrorLevel() > Issue.ERROR_WARN) {
-                    errorStatus = "FAIL";
-                    break;
-                }
-            }
+            errorStatus = "FAIL";
         }
 
         report.put("status", errorStatus);

--- a/client/src/main/java/org/daisy/validator/report/ReportGenerator.java
+++ b/client/src/main/java/org/daisy/validator/report/ReportGenerator.java
@@ -88,14 +88,8 @@ public class ReportGenerator {
         String guidelineName = guideline == null ? "Unknown" : guideline.getGuidelineName();
         text = text.replace("[GUIDELINE]", guidelineName);
 
-        int issueCount = 0;
-        for (Issue i : issues) {
-            issueCount += i.getErrorLevel() == Issue.ERROR_ERROR ? 1 : 0;
-            issueCount += i.getErrorLevel() == Issue.ERROR_FATAL ? 1 : 0;
-        }
-
-        String issueClass = issueCount > 0 ? "error" : "success";
-        text = text.replace("[ISSUES_FOUND]", String.format("<p class='%s'>%d issues found.</p>", issueClass, issueCount));
+        String issueClass = issues.size() > 0 ? "error" : "success";
+        text = text.replace("[ISSUES_FOUND]", String.format("<p class='%s'>%d issues found.</p>", issueClass, issues.size()));
 
         Map<String, List<Issue>> issuePerFile = sortByFile(issues);
         String report = "";

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
@@ -94,26 +94,6 @@
         </rule>
     </pattern>
 
-    <pattern id="opf_nordic_5_b">
-        <title>Rule 5b</title>
-        <p></p>
-        <rule context="opf:item[@media-type='application/x-dtbncx+xml']">
-            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="@href = 'nav.ncx'">[opf5b] the NCX must be located in the same directory as the package document, and must be named "nav.ncx" (not "<value-of select="@href"/>")</assert>
-        </rule>
-    </pattern>
-
-    <pattern id="opf_nordic_6">
-        <title>Rule 6</title>
-        <p></p>
-        <rule context="opf:spine">
-            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <let name="toc-doc" value="/opf:package/opf:manifest/opf:item[@media-type='application/x-dtbncx+xml']"/>
-            <assert test="not($toc-doc) or @toc">[opf6] the toc attribute must be present</assert>
-            <assert test="not($toc-doc) or $toc-doc/@id = @toc">[opf6] the toc attribute must refer to the nav.ncx item in the manifest</assert>
-        </rule>
-    </pattern>
-
     <pattern id="opf_nordic_7">
         <title>Rule 7</title>
         <p></p>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
@@ -94,6 +94,26 @@
         </rule>
     </pattern>
 
+    <pattern id="opf_nordic_5_b">
+        <title>Rule 5b</title>
+        <p></p>
+        <rule context="opf:item[@media-type='application/x-dtbncx+xml']">
+            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
+            <assert test="@href = 'nav.ncx'">[opf5b] the NCX must be located in the same directory as the package document, and must be named "nav.ncx" (not "<value-of select="@href"/>")</assert>
+        </rule>
+    </pattern>
+
+    <pattern id="opf_nordic_6">
+        <title>Rule 6</title>
+        <p></p>
+        <rule context="opf:spine">
+            <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
+            <let name="toc-doc" value="/opf:package/opf:manifest/opf:item[@media-type='application/x-dtbncx+xml']"/>
+            <assert test="not($toc-doc) or @toc">[opf6] the toc attribute must be present</assert>
+            <assert test="not($toc-doc) or $toc-doc/@id = @toc">[opf6] the toc attribute must refer to the nav.ncx item in the manifest</assert>
+        </rule>
+    </pattern>
+
     <pattern id="opf_nordic_7">
         <title>Rule 7</title>
         <p></p>


### PR DESCRIPTION
Hi @josteinaj 

This PR will solve two separate issues.

Not sure why it was implemented this way, it might have been an old request for change or a misunderstanding on my part about what the "report" rules in the schema were reporting.

But now I've changed it so all reported issues assert, reports, or general failures will end in the validator exiting with 1 as an error code, and all these will be counted as the general total issues.

Moreover, I've removed the requirements of an NCX file reported by the schema. The specification  https://github.com/kalaspuffar/nordic-epub3-dtbook-migrator/pull/new/loosen_requirement_of_ncx states that this is valid but not required.

I also added some convenience gitignores.

Best regards
Daniel