### PR TITLE
Fixing issue with parts and chapters being in differnt files.

### DIFF
--- a/client/src/main/resources/xslt/2015-1/list-heading-and-pagebreak-references.xsl
+++ b/client/src/main/resources/xslt/2015-1/list-heading-and-pagebreak-references.xsl
@@ -41,7 +41,7 @@
                 <xsl:if test="@id">
                     <xsl:attribute name="data-sectioning-id" select="@id"/>
                 </xsl:if>
-                <xsl:attribute name="data-sectioning-depth" select="count(ancestor::body | ancestor-or-self::section | ancestor-or-self::article)"/>
+                <xsl:attribute name="data-sectioning-depth" select="count(ancestor-or-self::body | ancestor-or-self::section | ancestor-or-self::article)"/>
             </c:result>
         </xsl:if>
         <xsl:apply-templates/>

--- a/client/src/main/resources/xslt/2020-1/list-heading-and-pagebreak-references.xsl
+++ b/client/src/main/resources/xslt/2020-1/list-heading-and-pagebreak-references.xsl
@@ -23,6 +23,12 @@
             <xsl:if test="$sectioning-element/@id">
                 <xsl:attribute name="data-sectioning-id" select="$sectioning-element/@id"/>
             </xsl:if>
+            <xsl:if test="//body/section/@epub:type">
+                <xsl:attribute name="data-document-epub-type" select="//body/section/@epub:type"/>
+            </xsl:if>
+            <xsl:if test="//body/section/@role">
+                <xsl:attribute name="data-document-role" select="//body/section/@role"/>
+            </xsl:if>
             <xsl:attribute name="data-heading-element" select="name()"/>
             <xsl:if test="@id">
                 <xsl:attribute name="data-heading-id" select="@id"/>

--- a/client/src/test/java/TestValid.java
+++ b/client/src/test/java/TestValid.java
@@ -108,7 +108,9 @@ public class TestValid {
             "C00000-09-part.xhtml",
             "C00000-10-chapter.xhtml",
             "C00000-11-conclusion.xhtml",
-            "C00000-12-toc.xhtml"
+            "C00000-12-toc.xhtml",
+            "C00000-13-part.xhtml",
+            "C00000-14-chapter.xhtml"
         );
 
         for (String filename : list) {

--- a/client/src/test/resources/valid2020/EPUB/C00000-01-cover.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-01-cover.xhtml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:nordic="http://www.mtm.se/epub/" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#">
-<head>
-    <meta charset="UTF-8"/>
-    <title>Valentin Haüy - the father of the education for the blind</title>
-    <meta content="C00000" name="dc:identifier"/>
-    <meta name="viewport" content="width=device-width"/>
-    <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
-</head>
-<body>
-<section aria-label="Cover" epub:type="cover" id="level1_1" role="doc-cover">
-    <section aria-label="Back cover" id="prodnote_1" class="render-optional rearcover">
-        <p>Gro försöker att få Runa på gott humör igen.</p>
-        <p>– Vi har det bara så långtråkigt. Du har tur. Du får gå ut och in i tornet. Alvilda och jag måste sitta här dag ut och dag in. Bara om natten får vi komma till kvinnosalen. Om det bara
-            snart ville kommma någon som kan slå ihjäl ormen.</p>
-        <p>Gro suckar djupt. Liksom Alvilda är hon trött på att vara inspärrad.</p>
-        <p>Alvilda tittar ner på sina bröder igen.</p>
-        <p>– Jag vill hellre lära mig att slåss, mumlar hon. Då skulle jag själv kunna slå ihjäl odjuret.</p>
-        <p>– Jag hörde nog vad du sa. Runa ruskar på huvudet. Du vet inte vad som är bäst för dig. Tänk på allt det besvär din pappa och mamma har haft. Först byggde de det här tornet av koppar.
-            Sedan har de skaffat en orm, som kan vakta din dygd. Många unga män har mist sina liv för din skull.</p>
-        <aside id="nested-prodnote-in-rearcover" epub:type="z3998:production" class="prodnote">
-            <p>Prodnote inside rearcover</p>
-        </aside>
-    </section>
-</section>
-</body>
+    <head>
+        <meta charset="UTF-8"/>
+        <title>Valentin Haüy - the father of the education for the blind</title>
+        <meta content="C00000" name="dc:identifier"/>
+        <meta name="viewport" content="width=device-width"/>
+        <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
+    </head>
+    <body>
+        <section aria-label="Cover" epub:type="cover" id="level1_1" role="doc-cover">
+            <section aria-label="Back cover" id="prodnote_1" class="render-optional rearcover">
+                <p>Gro försöker att få Runa på gott humör igen.</p>
+                <p>– Vi har det bara så långtråkigt. Du har tur. Du får gå ut och in i tornet. Alvilda och jag måste sitta här dag ut och dag in. Bara om natten får vi komma till kvinnosalen. Om det bara
+                    snart ville kommma någon som kan slå ihjäl ormen.</p>
+                <p>Gro suckar djupt. Liksom Alvilda är hon trött på att vara inspärrad.</p>
+                <p>Alvilda tittar ner på sina bröder igen.</p>
+                <p>– Jag vill hellre lära mig att slåss, mumlar hon. Då skulle jag själv kunna slå ihjäl odjuret.</p>
+                <p>– Jag hörde nog vad du sa. Runa ruskar på huvudet. Du vet inte vad som är bäst för dig. Tänk på allt det besvär din pappa och mamma har haft. Först byggde de det här tornet av koppar.
+                    Sedan har de skaffat en orm, som kan vakta din dygd. Många unga män har mist sina liv för din skull.</p>
+                <aside id="nested-prodnote-in-rearcover" epub:type="z3998:production" class="prodnote">
+                    <p>Prodnote inside rearcover</p>
+                </aside>
+            </section>
+        </section>
+    </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-02-toc.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-02-toc.xhtml
@@ -1,88 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:nordic="http://www.mtm.se/epub/" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#">
-<head>
-    <meta charset="UTF-8"/>
-    <title>Valentin Haüy - the father of the education for the blind</title>
-    <meta content="C00000" name="dc:identifier"/>
-    <meta name="viewport" content="width=device-width"/>
-    <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
-</head>
-<body>
-<section epub:type="frontmatter toc" id="toc_body" role="doc-toc">
-    <div role="doc-pagebreak" id="page_3" class="page-front" epub:type="pagebreak" title="iii"></div>
-    <h1>Table of contents</h1>
-    <ol>
-        <li>
-            <a href="C00000-01-cover.xhtml#level1_1">
-                <span>Cover</span>
-            </a>
+    <head>
+        <meta charset="UTF-8"/>
+        <title>Valentin Haüy - the father of the education for the blind</title>
+        <meta content="C00000" name="dc:identifier"/>
+        <meta name="viewport" content="width=device-width"/>
+        <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
+    </head>
+    <body>
+        <section epub:type="frontmatter toc" id="toc_body" role="doc-toc">
+            <div role="doc-pagebreak" id="page_3" class="page-front" epub:type="pagebreak" title="iii"></div>
+            <h1>Table of contents</h1>
             <ol>
                 <li>
-                    <a href="C00000-01-cover.xhtml#prodnote_1">
-                        <span>Rear cover</span>
+                    <a href="C00000-01-cover.xhtml#level1_1">
+                        <span>Cover</span>
+                    </a>
+                    <ol>
+                        <li>
+                            <a href="C00000-01-cover.xhtml#prodnote_1">
+                                <span>Rear cover</span>
+                            </a>
+                        </li>
+                    </ol>
+                </li>
+                <li>
+                    <a href="C00000-02-toc.xhtml#toc-h1">
+                        <span>Table of contents</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="C00000-03-frontmatter.xhtml#d910e43">
+                        <span>Valentin Haüy - the father of the education for the blind</span>
+                    </a>
+                    <ol>
+                        <li>
+                            <a href="C00000-03-frontmatter.xhtml#d910e124">
+                                <span>List of contents</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="C00000-03-frontmatter.xhtml#d910e617">
+                                <span>Preface</span>
+                            </a>
+                        </li>
+                    </ol>
+                </li>
+                <li>
+                    <a href="C00000-04-chapter.xhtml#d910e694">
+                        <span class="lic">1.</span>
+                        <span class="lic">Research questions</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="C00000-05-chapter.xhtml#d910e770">
+                        <span class="lic">2.</span>
+                        <span class="lic">Purpose, method and sources</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="C00000-06-chapter.xhtml#d910e1012">
+                        <span class="lic">3.</span>
+                        <span class="lic">Valentin Haüy</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="C00000-08-chapter.xhtml#d910e3694">
+                        <span class="lic">4.</span>
+                        <span class="lic">The importance of Haüy in the education of the blind in Sweden and elsewhere extra long title extra long title extra long title extra long title</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="C00000-11-conclusion.xhtml#d910e4160">
+                        <span class="lic">5.</span>
+                        <span class="lic">Discussion and conclusions</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="C00000-12-footnotes.xhtml#d910e4513">
+                        <span>Footnotes</span>
                     </a>
                 </li>
             </ol>
-        </li>
-        <li>
-            <a href="C00000-02-toc.xhtml#toc-h1">
-                <span>Table of contents</span>
-            </a>
-        </li>
-        <li>
-            <a href="C00000-03-frontmatter.xhtml#d910e43">
-                <span>Valentin Haüy - the father of the education for the blind</span>
-            </a>
-            <ol>
-                <li>
-                    <a href="C00000-03-frontmatter.xhtml#d910e124">
-                        <span>List of contents</span>
-                    </a>
-                </li>
-                <li>
-                    <a href="C00000-03-frontmatter.xhtml#d910e617">
-                        <span>Preface</span>
-                    </a>
-                </li>
-            </ol>
-        </li>
-        <li>
-            <a href="C00000-04-chapter.xhtml#d910e694">
-                <span class="lic">1.</span>
-                <span class="lic">Research questions</span>
-            </a>
-        </li>
-        <li>
-            <a href="C00000-05-chapter.xhtml#d910e770">
-                <span class="lic">2.</span>
-                <span class="lic">Purpose, method and sources</span>
-            </a>
-        </li>
-        <li>
-            <a href="C00000-06-chapter.xhtml#d910e1012">
-                <span class="lic">3.</span>
-                <span class="lic">Valentin Haüy</span>
-            </a>
-        </li>
-        <li>
-            <a href="C00000-08-chapter.xhtml#d910e3694">
-                <span class="lic">4.</span>
-                <span class="lic">The importance of Haüy in the education of the blind in Sweden and elsewhere extra long title extra long title extra long title extra long title</span>
-            </a>
-        </li>
-        <li>
-            <a href="C00000-11-conclusion.xhtml#d910e4160">
-                <span class="lic">5.</span>
-                <span class="lic">Discussion and conclusions</span>
-            </a>
-        </li>
-        <li>
-            <a href="C00000-12-footnotes.xhtml#d910e4513">
-                <span>Footnotes</span>
-            </a>
-        </li>
-    </ol>
-</section>
-</body>
+        </section>
+    </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-03-frontmatter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-03-frontmatter.xhtml
@@ -107,412 +107,414 @@
         <link rel="prev" href="C00000-02-toc.xhtml" />
         <link rel="next" href="C00000-04-chapter.xhtml" />
     </head>
-    <body id="d910e43" epub:type="frontmatter">
-        <h1>Valentin Haüy - the father of the education for the blind</h1>
-        <p>
-            <span id="dtb4">Published by the Swedish Library of Talking Books and Braille (<abbr title="The Swedish Library of Talking Books and Braille" id="d910e49" epub:type="z3998:initialism"
-                    class="initialism">MTM</abbr>).</span>
-        </p>
-        <figure id="d910e54" class="image">
-            <img id="d910e56" alt="image" src="images/valentin.jpg" />
-            <figcaption id="d910e58">
-                <span id="dtb5">Valentin Haüy</span>
-            </figcaption>
-        </figure>
-        <figure id="d910e54-test" class="image">
-            <img id="d910e56-test" alt="image" src="images/valentin.jpg" />
-            <figcaption id="d910e58-test">
-                <span id="dtb5-test">Valentin Haüy</span>
-            </figcaption>
-        </figure>
-        <div id="image-tests">
-            <div>
-                <!-- image in block context - with placeholder alt text: -->
-                <img id="image-tests-img-1" src="images/valentin.jpg" alt="image" />
+    <body>
+        <section id="d910e43" epub:type="frontmatter">
+            <h1>Valentin Haüy - the father of the education for the blind</h1>
+            <p>
+                <span id="dtb4">Published by the Swedish Library of Talking Books and Braille (<abbr title="The Swedish Library of Talking Books and Braille" id="d910e49" epub:type="z3998:initialism"
+                        class="initialism">MTM</abbr>).</span>
+            </p>
+            <figure id="d910e54" class="image">
+                <img id="d910e56" alt="image" src="images/valentin.jpg" />
+                <figcaption id="d910e58">
+                    <span id="dtb5">Valentin Haüy</span>
+                </figcaption>
+            </figure>
+            <figure id="d910e54-test" class="image">
+                <img id="d910e56-test" alt="image" src="images/valentin.jpg" />
+                <figcaption id="d910e58-test">
+                    <span id="dtb5-test">Valentin Haüy</span>
+                </figcaption>
+            </figure>
+            <div id="image-tests">
+                <div>
+                    <!-- image in block context - with placeholder alt text: -->
+                    <img id="image-tests-img-1" src="images/valentin.jpg" alt="image" />
+                </div>
+                <div>
+                    <!-- image in inline context - with placeholder alt text: -->
+                    <p>
+                        <img id="image-tests-img-2" src="images/valentin.jpg" alt="image" />
+                    </p>
+                </div>
+                <div>
+                    <!-- image in figure - with placeholder alt text: -->
+                    <figure id="image-tests-figure-1" class="image">
+                        <img id="image-tests-img-3" src="images/valentin.jpg" alt="image" />
+                    </figure>
+                </div>
+                <div>
+                    <!-- image in image series figure - with placeholder alt text: -->
+                    <figure id="image-tests-figure-2" class="image-series">
+                        <figure class="image">
+                            <img id="image-tests-img-4" src="images/valentin.jpg" alt="image" />
+                        </figure>
+                        <figure class="image">
+                            <img id="image-tests-img-5" src="images/valentin.jpg" alt="image" />
+                        </figure>
+                    </figure>
+                </div>
+                <div>
+                    <!-- image in block context - decorative: -->
+                    <img id="image-tests-img-6" src="images/valentin.jpg" alt="" />
+                </div>
+                <div>
+                    <!-- image in inline context - decorative: -->
+                    <p>
+                        <img id="image-tests-img-7" src="images/valentin.jpg" alt="" />
+                    </p>
+                </div>
+                <div>
+                    <!-- image in block context - with custom alt text: -->
+                    <img id="image-tests-img-11" src="images/valentin.jpg" alt="中国文字" />
+                </div>
+                <div>
+                    <!-- image in inline context - with custom alt text: -->
+                    <p>
+                        <img id="image-tests-img-12" src="images/valentin.jpg" alt="中国文字" />
+                    </p>
+                </div>
+                <div>
+                    <!-- image in figure - with custom alt text: -->
+                    <figure id="image-tests-figure-8" class="image">
+                        <img id="image-tests-img-13" src="images/valentin.jpg" alt="中国文字" />
+                    </figure>
+                </div>
+                <div>
+                    <!-- image in image series figure - with custom alt text: -->
+                    <figure id="image-tests-figure-9" class="image-series">
+                        <figure class="image">
+                            <img id="image-tests-img-14" src="images/valentin.jpg" alt="中国文字" />
+                        </figure>
+                        <figure class="image">
+                            <img id="image-tests-img-15" src="images/valentin.jpg" alt="中国文字" />
+                        </figure>
+                    </figure>
+                </div>
             </div>
-            <div>
-                <!-- image in inline context - with placeholder alt text: -->
+            <p class="paragraphs can have many different classes">Paragraphs can have many different classes</p>
+            <aside id="dtb6" class="prodnote" epub:type="z3998:production">
                 <p>
-                    <img id="image-tests-img-2" src="images/valentin.jpg" alt="image" />
+                    <span id="dtb7">This version is a for-test-use-only modification of the published original.</span>
                 </p>
-            </div>
-            <div>
-                <!-- image in figure - with placeholder alt text: -->
-                <figure id="image-tests-figure-1" class="image">
-                    <img id="image-tests-img-3" src="images/valentin.jpg" alt="image" />
-                </figure>
-            </div>
-            <div>
-                <!-- image in image series figure - with placeholder alt text: -->
-                <figure id="image-tests-figure-2" class="image-series">
-                    <figure class="image">
-                        <img id="image-tests-img-4" src="images/valentin.jpg" alt="image" />
-                    </figure>
-                    <figure class="image">
-                        <img id="image-tests-img-5" src="images/valentin.jpg" alt="image" />
-                    </figure>
-                </figure>
-            </div>
-            <div>
-                <!-- image in block context - decorative: -->
-                <img id="image-tests-img-6" src="images/valentin.jpg" alt="" />
-            </div>
-            <div>
-                <!-- image in inline context - decorative: -->
                 <p>
-                    <img id="image-tests-img-7" src="images/valentin.jpg" alt="" />
+                    <span id="dtb8">Modifications have been done primarily to the footnotes, which in the original version used inline parentheses, and in this version use a noteref-endnote system.</span>
                 </p>
-            </div>
-            <div>
-                <!-- image in block context - with custom alt text: -->
-                <img id="image-tests-img-11" src="images/valentin.jpg" alt="中国文字" />
-            </div>
-            <div>
-                <!-- image in inline context - with custom alt text: -->
+            </aside>
+            <p>
+                <span id="dtb9">In this study the life and works of Valentin Haüy are described. </span>
+                <span id="dtb10">Valentin Haüy (1745-1821), of many called the father of the education of the blind, founded a school for blind children of both sexes in Paris in 1785. </span>
+                <span id="dtb11">In 1786 he published the first known book about education for the blind. </span>
+                <span id="dtb12">His main idea was the necessity of educating the blind to an independent life. </span>
+                <span id="dtb13">Thus the blind were trained for different professions such as printing, basket making, sewing etc. </span>
+                <span id="dtb14">Another of Haüys ideas was that blind children should not be segregated but educated together with sighted children. </span>
+                <span id="dtb15">His method of printing books with letters in relief and ink-print was a minor revolution that enabled the blind to read books. </span>
+            </p>
+            <p>
+                <span id="dtb16">In the study a hitherto unknown period in Haüys life is described. </span>
+                <span id="dtb17">It is the period 1807-1820 which he spent in St Petersburg, then the capital of Russia. </span>
+                <span id="dtb18">In the study there is also an analysis of Haüy’s influence on the education of the blind in other European countries. </span>
+            </p>
+            <p>
+                <span id="dtb19">Key words: Valentin Haüy, education of the blind, relief print, visual communication, history</span>
+            </p>
+            <section id="d910e124">
+                <h2 id="d910e126">List of contents</h2>
+                <table id="dtb21">
+                    <tbody>
+                        <tr id="dtb22">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb23">Preface</span>
+                            </td>
+                            <td rowspan="1" colspan="1"></td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb24">4</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb25">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb26">1.</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb27">Research questions</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb28">5</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb29">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb30">2.</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb31">Purpose, method and sources</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb32">5</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb33">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb34">3.</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb35">Valentin Haüy</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb36">7</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb37">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb38">3.1</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb39">Introduction</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb40">7</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb41">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb42">3.2</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb43">Biographical background</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb44">8</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb45">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb46">3.3</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb47">The market in St Ovid's Square</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb48">8</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb49">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb50">3.4</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb51">Maria Theresia von Paradis (1733-1808)</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb52">9</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb53">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb54">3.5</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb55">Haüy's meeting with Lesueur and the foundation of l'Institution des Jeunes Aveugles</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb56">10</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb57">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb58">3.6</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb59">Valentin Haüy's teaching methods</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb60">11</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb61">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb62">3.7</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb63">The French revolution</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb64">13</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb65">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb66">3.8</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb67">Musée des Aveugles</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb68">14</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb69">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb70">3.9</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb71">Valentin Haüy in Russia</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb72">15</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb73">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb74">3.9.1</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb75">An invitation from Alexander I</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb76">15</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb77">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb78">3.9.2</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb79">Berlin</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb80">16</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb81">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb82">3.9.3</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb83">In St Petersburg</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb84">16</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb85">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb86">3.9.4</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb87">Haüy's last will and testament</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb88">20</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb89">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb90">3.9.5</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb91">Education of deaf pupils in St Petersburg</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb92">21</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb93">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb94">3.10</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb95">Haüy's telegraph</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb96">22</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb97">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb98">3.11</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb99">The final years</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb100">22</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb101">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb102">4.</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb103">The importance of Haüy in the education of the blind in Sweden and other countries</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb104">23</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb105">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb106">5.</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb107">Discussion and conclusions</span>
+                            </td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb108">26</span>
+                            </td>
+                        </tr>
+                        <tr id="dtb109">
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb110">References</span>
+                            </td>
+                            <td rowspan="1" colspan="1"></td>
+                            <td rowspan="1" colspan="1">
+                                <span id="dtb111">29</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div id="page_4" class="page-front" epub:type="pagebreak" title="iv"></div>
+                <div epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page-vii" aria-label="vii"></div>
                 <p>
-                    <img id="image-tests-img-12" src="images/valentin.jpg" alt="中国文字" />
+                    <span epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page-viii" aria-label="viii"></span>
                 </p>
-            </div>
-            <div>
-                <!-- image in figure - with custom alt text: -->
-                <figure id="image-tests-figure-8" class="image">
-                    <img id="image-tests-img-13" src="images/valentin.jpg" alt="中国文字" />
-                </figure>
-            </div>
-            <div>
-                <!-- image in image series figure - with custom alt text: -->
-                <figure id="image-tests-figure-9" class="image-series">
-                    <figure class="image">
-                        <img id="image-tests-img-14" src="images/valentin.jpg" alt="中国文字" />
-                    </figure>
-                    <figure class="image">
-                        <img id="image-tests-img-15" src="images/valentin.jpg" alt="中国文字" />
-                    </figure>
-                </figure>
-            </div>
-        </div>
-        <p class="paragraphs can have many different classes">Paragraphs can have many different classes</p>
-        <aside id="dtb6" class="prodnote" epub:type="z3998:production">
-            <p>
-                <span id="dtb7">This version is a for-test-use-only modification of the published original.</span>
-            </p>
-            <p>
-                <span id="dtb8">Modifications have been done primarily to the footnotes, which in the original version used inline parentheses, and in this version use a noteref-endnote system.</span>
-            </p>
-        </aside>
-        <p>
-            <span id="dtb9">In this study the life and works of Valentin Haüy are described. </span>
-            <span id="dtb10">Valentin Haüy (1745-1821), of many called the father of the education of the blind, founded a school for blind children of both sexes in Paris in 1785. </span>
-            <span id="dtb11">In 1786 he published the first known book about education for the blind. </span>
-            <span id="dtb12">His main idea was the necessity of educating the blind to an independent life. </span>
-            <span id="dtb13">Thus the blind were trained for different professions such as printing, basket making, sewing etc. </span>
-            <span id="dtb14">Another of Haüys ideas was that blind children should not be segregated but educated together with sighted children. </span>
-            <span id="dtb15">His method of printing books with letters in relief and ink-print was a minor revolution that enabled the blind to read books. </span>
-        </p>
-        <p>
-            <span id="dtb16">In the study a hitherto unknown period in Haüys life is described. </span>
-            <span id="dtb17">It is the period 1807-1820 which he spent in St Petersburg, then the capital of Russia. </span>
-            <span id="dtb18">In the study there is also an analysis of Haüy’s influence on the education of the blind in other European countries. </span>
-        </p>
-        <p>
-            <span id="dtb19">Key words: Valentin Haüy, education of the blind, relief print, visual communication, history</span>
-        </p>
-        <section id="d910e124">
-            <h2 id="d910e126">List of contents</h2>
-            <table id="dtb21">
-                <tbody>
-                    <tr id="dtb22">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb23">Preface</span>
-                        </td>
-                        <td rowspan="1" colspan="1"></td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb24">4</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb25">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb26">1.</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb27">Research questions</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb28">5</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb29">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb30">2.</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb31">Purpose, method and sources</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb32">5</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb33">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb34">3.</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb35">Valentin Haüy</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb36">7</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb37">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb38">3.1</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb39">Introduction</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb40">7</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb41">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb42">3.2</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb43">Biographical background</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb44">8</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb45">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb46">3.3</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb47">The market in St Ovid's Square</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb48">8</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb49">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb50">3.4</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb51">Maria Theresia von Paradis (1733-1808)</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb52">9</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb53">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb54">3.5</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb55">Haüy's meeting with Lesueur and the foundation of l'Institution des Jeunes Aveugles</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb56">10</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb57">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb58">3.6</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb59">Valentin Haüy's teaching methods</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb60">11</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb61">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb62">3.7</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb63">The French revolution</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb64">13</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb65">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb66">3.8</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb67">Musée des Aveugles</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb68">14</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb69">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb70">3.9</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb71">Valentin Haüy in Russia</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb72">15</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb73">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb74">3.9.1</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb75">An invitation from Alexander I</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb76">15</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb77">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb78">3.9.2</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb79">Berlin</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb80">16</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb81">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb82">3.9.3</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb83">In St Petersburg</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb84">16</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb85">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb86">3.9.4</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb87">Haüy's last will and testament</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb88">20</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb89">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb90">3.9.5</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb91">Education of deaf pupils in St Petersburg</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb92">21</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb93">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb94">3.10</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb95">Haüy's telegraph</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb96">22</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb97">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb98">3.11</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb99">The final years</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb100">22</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb101">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb102">4.</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb103">The importance of Haüy in the education of the blind in Sweden and other countries</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb104">23</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb105">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb106">5.</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb107">Discussion and conclusions</span>
-                        </td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb108">26</span>
-                        </td>
-                    </tr>
-                    <tr id="dtb109">
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb110">References</span>
-                        </td>
-                        <td rowspan="1" colspan="1"></td>
-                        <td rowspan="1" colspan="1">
-                            <span id="dtb111">29</span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <div id="page_4" class="page-front" epub:type="pagebreak" title="iv"></div>
-            <div epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page-vii" aria-label="vii"></div>
-            <p>
-                <span epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page-viii" aria-label="viii"></span>
-            </p>
-        </section>
-        <section id="d910e617">
-            <h2 id="d910e619">Preface</h2>
-            <p>
-                <span id="dtb113">During my 19 years at the Swedish Library of Talking Books and Braille (<abbr title="The Swedish Library of Talking Books and Braille" id="d910e629"
-                        epub:type="z3998:initialism" class="initialism">MTM</abbr>), I have frequently been asked about the history of the Braille system and these questions were really what motivated
-                    my research into the life of Louis Braille, the inventor of the system of writing for the blind which was named after him. </span>
-                <span id="dtb114">My investigations revealed that Louis Braille himself would have had almost no schooling at all if it had not been for Valentin Haüy, the father of education for the
-                    blind.</span>
-            </p>
-            <p>
-                <span id="dtb115">As there is very little literature available in Swedish on either Valentin Haüy or Louis Braille, the two principle figures in the history of education for the blind,
-                    I decided to do something to remedy this. </span>
-                <span id="dtb116">I starrrrted with Louis Braille, the inventor of the system of writing for the blind which is in use today, and when I had finished my studies of Braille's life, I
-                    naturally went on to investigate the life of Valentin Haüy. </span>
-                <span id="dtb117">At the time I had to write a paper on education for the blind, as part of my studies at the Department of Education (Stockholm university), so I decided to kill two
-                    birds with one stone and combine both tasks.</span>
-            </p>
-            <p>
-                <span id="dtb118">Working on this paper was no easy task as so few sources can be consulted in Sweden. </span>
-                <span id="dtb119">There is an international lending network, but borrowing books is a slow process since foreign libraries do not always deliver by airmail. </span>
-                <span id="dtb120">My principal source was thus the library at the Danish Museum of the Blind, originally the library of the Royal Institute for the Blind. </span>
-                <span id="dtb121">It was there that I came across a copy of Haüy's first book on education for the blind.</span>
-            </p>
-            <p>
-                <span id="dtb122">I particularly wish to thank Mogens Bang, head of the Danish Museum of the Blind, who made it possible for me to spend time in the museum sifting through the material
-                    in their unique collection of older books on education for the blind.</span>
-            </p>
-            <p>
-                <span id="dtb123">I would also like to thank Marie Strömbäck and Kerstin Wallin, who helped me with the translations from French. </span>
-                <span id="dtb124">Finally, I am much obliged to Eric Engström, my tutor, for inspiring and encouraging me in my work.</span>
-            </p>
-            <p>
-                <span id="dtb125">Beatrice Christensen-Sköld</span>
-            </p>
-            <div id="page_front_5" class="page-front" epub:type="pagebreak" title="v"></div>
+            </section>
+            <section id="d910e617">
+                <h2 id="d910e619">Preface</h2>
+                <p>
+                    <span id="dtb113">During my 19 years at the Swedish Library of Talking Books and Braille (<abbr title="The Swedish Library of Talking Books and Braille" id="d910e629"
+                            epub:type="z3998:initialism" class="initialism">MTM</abbr>), I have frequently been asked about the history of the Braille system and these questions were really what motivated
+                        my research into the life of Louis Braille, the inventor of the system of writing for the blind which was named after him. </span>
+                    <span id="dtb114">My investigations revealed that Louis Braille himself would have had almost no schooling at all if it had not been for Valentin Haüy, the father of education for the
+                        blind.</span>
+                </p>
+                <p>
+                    <span id="dtb115">As there is very little literature available in Swedish on either Valentin Haüy or Louis Braille, the two principle figures in the history of education for the blind,
+                        I decided to do something to remedy this. </span>
+                    <span id="dtb116">I starrrrted with Louis Braille, the inventor of the system of writing for the blind which is in use today, and when I had finished my studies of Braille's life, I
+                        naturally went on to investigate the life of Valentin Haüy. </span>
+                    <span id="dtb117">At the time I had to write a paper on education for the blind, as part of my studies at the Department of Education (Stockholm university), so I decided to kill two
+                        birds with one stone and combine both tasks.</span>
+                </p>
+                <p>
+                    <span id="dtb118">Working on this paper was no easy task as so few sources can be consulted in Sweden. </span>
+                    <span id="dtb119">There is an international lending network, but borrowing books is a slow process since foreign libraries do not always deliver by airmail. </span>
+                    <span id="dtb120">My principal source was thus the library at the Danish Museum of the Blind, originally the library of the Royal Institute for the Blind. </span>
+                    <span id="dtb121">It was there that I came across a copy of Haüy's first book on education for the blind.</span>
+                </p>
+                <p>
+                    <span id="dtb122">I particularly wish to thank Mogens Bang, head of the Danish Museum of the Blind, who made it possible for me to spend time in the museum sifting through the material
+                        in their unique collection of older books on education for the blind.</span>
+                </p>
+                <p>
+                    <span id="dtb123">I would also like to thank Marie Strömbäck and Kerstin Wallin, who helped me with the translations from French. </span>
+                    <span id="dtb124">Finally, I am much obliged to Eric Engström, my tutor, for inspiring and encouraging me in my work.</span>
+                </p>
+                <p>
+                    <span id="dtb125">Beatrice Christensen-Sköld</span>
+                </p>
+                <div id="page_front_5" class="page-front" epub:type="pagebreak" title="v"></div>
+            </section>
         </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
@@ -116,16 +116,16 @@
             <div id="page_7" class="page-normal" epub:type="pagebreak" aria-label="7"></div>
             <h1 id="d910e696">1. Research questions</h1>
             <pre><code>
-        public static void main(String[] args) {
-            ...
-        }
-        </code></pre>
+                public static void main(String[] args) {
+                ...
+                }
+            </code></pre>
             <hr class="separator"/>
             <pre><code>
-        public static void main(String[] args) {
-            ...
-        }
-        </code></pre>
+                public static void main(String[] args) {
+                ...
+                }
+            </code></pre>
             <p>
                 <span id="dtb128">My interest in Valentin Haüy, the father of education for the blind in Europe, was aroused while working at <abbr title="The Swedish Library of Talking Books and Braille"
                         id="d910e709" epub:type="z3998:initialism" class="initialism">MTM</abbr> on a book about Louis Braille, the creator of the Braille system. </span>
@@ -257,8 +257,6 @@
                     </div>
                 </section>
             </section>
-
-
         </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
@@ -107,110 +107,112 @@
         <link rel="prev" href="C00000-04-chapter.xhtml" />
         <link rel="next" href="C00000-06-chapter.xhtml" />
     </head>
-    <body id="d910e770" epub:type="bodymatter chapter">
-        <h1 id="d910e772">2. Purpose, method and sources</h1>
-        <p>
-            <span id="dtb142">My purpose in this paper is to shed some light on Valentin Haüy, the person, and the role he played in the history of education for the blind, and to attempt to ascertain
-                whether he was influential in the introduction of education for the blind in other countries, particularly in Sweden.</span>
-        </p>
-        <p>
-            <span id="dtb143">For obvious reasons, I have chosen a hermeneutic method. </span>
-            <span id="dtb144">I was unable, of course, to interview Valentin Haüy in person; he has been dead for nearly 200 years. </span>
-            <span id="dtb145">Initially, I had in mind the idea of adopting an idiographic approach to my investigation but found this difficult to apply to an historical personage such as Haüy. </span>
-            <span id="dtb146">However, it was, above all, the lack of first-hand sources which most discouraged me.</span>
-        </p>
-        <p>
-            <span id="dtb147">In historical research, one must have access to the remains or traces of "reality in the past tense," as Sjöstrand (1972) put it. </span>
-            <span id="dtb148">The researcher pieces together, in a manner of speaking, a mosaic from the fragments he manages to find. </span>
-            <span id="d910e810">
-                <span id="dtb149">These remains and traces may be many and varied; in the case of Haüy, they are mainly written sources </span>
-                <a id="dtb150" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_1">1</a>
-                <span id="dtb151">.</span>
-            </span>
-        </p>
-        <p>
-            <span id="dtb152">One of the purposes of this paper is to create a portrait in writing of Valentin Haüy. </span>
-            <span id="dtb153">In other words, a biography. </span>
-            <span id="d910e831">
-                <span id="dtb154">When writing a biography, one should make use of material which directly or indirectly, in part or completely provides information about the life of one or several
-                    people </span>
-                <a id="dtb155" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_2">2</a>
-                <span id="dtb156">. </span>
-            </span>
-            <span id="dtb157">This may or may not be written material. </span>
-            <span id="dtb158">Written material produced by the investigated person himself or herself is, according to Engström, "first-person documentation," while material about the person
-                investigated is "third-person documentation". </span>
-            <span id="d910e850">
-                <span id="dtb159">The lack of first-hand sources naturally means that the validity of this type of documentation is questionable </span>
-                <a id="dtb160" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_3">3</a>
-                <span id="dtb161">. </span>
-            </span>
-            <span id="dtb162">However, some of the documentation I have used does in fact quote from first-hand sources or "first-person documents". </span>
-            <span id="dtb163">To judge from the literature available on the subject, I am one of the very few (if not the only) researchers who have used Skrébitsky as a source.</span>
-        </p>
-        <div id="page_6" class="page-normal" epub:type="pagebreak" title="6"></div>
-        <p>
-            <span id="dtb164">I did have access to a single first-hand source - the information I use to describe Haüy's pedagogical methods was, in part, gleaned from his own Essai sur l'Education
-                des Aveugles.</span>
-        </p>
-        <p>
-            <span id="dtb165">I have hunted for sources in museums and archives where most of the material available was in printed form. </span>
-            <span id="dtb166">The few hand-written documents in existence are in the possession of the Association Valentin Haüy in Paris.</span>
-        </p>
-        <p>
-            <span id="dtb167">Most of the documents I have used for this paper are in the library at the Danish Museum of the Blind, which is the only Nordic library that possesses a copy of Valentin
-                Haüy's Essai de l'Education des Jeunes Aveugles, together with the Institution des Jeunes Aveugles' annual reports. </span>
-            <span id="dtb168">One of these reports merits special attention since it contains a relatively early biographical article on Valentin Haüy written by the director of the institute, Dr P-A
-                Dufau. </span>
-            <span id="dtb169">The report is dated 1852, when the institute transferred to its present location in the Boulevard des Invalides. </span>
-            <span id="dtb170">The article in question was written in 1844 and was published separately. </span>
-            <span id="dtb171">Dufau's main source is a letter written by Valentin Haüy to his son.</span>
-        </p>
-        <p>
-            <span id="dtb172">Paul Henri, head of the Association Valentin Haüy in the 1950s, in his biography of Louis Braille (The Life and Work of Louis Braille 1809-1852) dedicated an ample
-                section to Valentin Haüy and his pioneering work in the field of education for the blind. </span>
-            <span id="dtb173">His biography first appeared in France in the 1950s in a Braille version and was later, on the decision of the World Blind Union, translated into English and published by
-                the South African National Council for the Blind in 1987. </span>
-            <span id="dtb174">According to Didier-Weygand (2000), Henri also published a separate biography of Valentin Haüy (Paris, 1984), but unfortunately this information reached me only when the
-                present paper was to all intents and purposes completed.</span>
-        </p>
-        <p>
-            <span id="dtb175">Existing literature tends to ignore Valentin Haüy's stay in St Petersburg. so I have paid particular attention to that period in his life. </span>
-            <span id="dtb176">A valuable source was the Russian ophtalmologist Alexander Skrébitsky's little publication, Valentin Haüy à St. </span>
-            <span id="dtb177">Petersbourg (1884). </span>
-            <span id="dtb178">Skrébitsky can be said to have rediscovered Haüy in Russia during his own attempts to improve conditions for the blind. </span>
-            <span id="dtb179">Haüy's institute for the blind in St Petersburg had by then been closed and forgotten for many years, but Skrébitsky found material in its archives on which he based his
-                book. </span>
-            <span id="dtb180">There was, for example, a box full of documents dating from the period 1807-1809, but only a few documents from the latter part of Haüy's stay in Russia. </span>
-            <span id="d910e939">
-                <span id="dtb181">Skrébitsky managed to smuggle the box out of Russia and donated it to the Valentin Haüy Museum in Paris where it is still kept </span>
-                <a id="dtb182" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_4">4</a>
-                <span id="dtb183">. </span>
-            </span>
-            <span id="dtb184">I have been able to ascertain that this information is correct, but have not had the opportunity to consult these documents personally. </span>
-            <span id="dtb185">I trust that Skrébitsky's quotations from them are accurate.</span>
-        </p>
-        <p>
-            <span id="dtb186">The French historian Zina Weygand published a booklet entitled Les Temps des Fondateurs 1784-1844 for the second Congress on the history of the blind in Paris in 1998. </span>
-            <span id="dtb187">Her booklet is interesting as she had access to the archives of the Institution des Jeunes Aveugles (INJA) created by Valentin Haüy, the Bibliothèque National de France,
-                the Bibliothèque Association Valentin Haüy, as well as those of the Archive du C.N.H.O. des Quinze-Vingt. </span>
-            <span id="dtb188">Her booklet is only a foretaste of her doctoral thesis, La Cécité et les Aveugles dans la Société Française: Représentations et Institution du Moyen Âge aux Premières
-                Années du XIX Siècle, published in March 2000. </span>
-            <span id="dtb189">Weygand married shortly after the Paris Congress and now uses a double surname, Didier-Weygand. </span>
-            <span id="dtb190">Her sources include documents from archives, press cuttings and documents and letters written by Haüy himself. </span>
-            <span id="dtb191">She is the only researcher to have made use of the minutes kept by the various revolutionary committees in Paris during the 1790s. </span>
-            <span id="dtb192">She does not, however, write about Haüy's years in Russia.</span>
-        </p>
-        <div id="page_7" class="page-normal" epub:type="pagebreak" title="7"></div>
-        <p>
-            <span id="dtb193">To illustrate Haüy's influence on the development of education for the blind in other countries, I have chosen D.G. </span>
-            <span id="dtb194">Pritchard's Education and the Handicapped 1760-1960 (1963) as my main source since it is considered a standard work. </span>
-            <span id="dtb195">My sources on the work of pioneers in the education of the blind in Sweden are O.E. </span>
-            <span id="dtb196">Borg's Minnen från den svenska blindundervisningens <span id="d910e1000" class="num-word">70-års</span> jubileum den 21 maj 1883, Kjell-åke Johanssons research report Om
-                blindundervisningen i Sverige från 1809 (1974) and Staffan Förhammar's doctoral thesis Från tärande till närande (1991).</span>
-        </p>
-        <p>
-            <span id="dtb197">I have also consulted press articles, amongst them Marlene Jantsch's article on Maria Theresia von Paradis, in the Wiener Medizinische Wochenschrift 47/1955.</span>
-        </p>
+    <body>
+        <section id="d910e770" epub:type="bodymatter chapter">
+            <h1 id="d910e772">2. Purpose, method and sources</h1>
+            <p>
+                <span id="dtb142">My purpose in this paper is to shed some light on Valentin Haüy, the person, and the role he played in the history of education for the blind, and to attempt to ascertain
+                    whether he was influential in the introduction of education for the blind in other countries, particularly in Sweden.</span>
+            </p>
+            <p>
+                <span id="dtb143">For obvious reasons, I have chosen a hermeneutic method. </span>
+                <span id="dtb144">I was unable, of course, to interview Valentin Haüy in person; he has been dead for nearly 200 years. </span>
+                <span id="dtb145">Initially, I had in mind the idea of adopting an idiographic approach to my investigation but found this difficult to apply to an historical personage such as Haüy. </span>
+                <span id="dtb146">However, it was, above all, the lack of first-hand sources which most discouraged me.</span>
+            </p>
+            <p>
+                <span id="dtb147">In historical research, one must have access to the remains or traces of "reality in the past tense," as Sjöstrand (1972) put it. </span>
+                <span id="dtb148">The researcher pieces together, in a manner of speaking, a mosaic from the fragments he manages to find. </span>
+                <span id="d910e810">
+                    <span id="dtb149">These remains and traces may be many and varied; in the case of Haüy, they are mainly written sources </span>
+                    <a id="dtb150" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_1">1</a>
+                    <span id="dtb151">.</span>
+                </span>
+            </p>
+            <p>
+                <span id="dtb152">One of the purposes of this paper is to create a portrait in writing of Valentin Haüy. </span>
+                <span id="dtb153">In other words, a biography. </span>
+                <span id="d910e831">
+                    <span id="dtb154">When writing a biography, one should make use of material which directly or indirectly, in part or completely provides information about the life of one or several
+                        people </span>
+                    <a id="dtb155" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_2">2</a>
+                    <span id="dtb156">. </span>
+                </span>
+                <span id="dtb157">This may or may not be written material. </span>
+                <span id="dtb158">Written material produced by the investigated person himself or herself is, according to Engström, "first-person documentation," while material about the person
+                    investigated is "third-person documentation". </span>
+                <span id="d910e850">
+                    <span id="dtb159">The lack of first-hand sources naturally means that the validity of this type of documentation is questionable </span>
+                    <a id="dtb160" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_3">3</a>
+                    <span id="dtb161">. </span>
+                </span>
+                <span id="dtb162">However, some of the documentation I have used does in fact quote from first-hand sources or "first-person documents". </span>
+                <span id="dtb163">To judge from the literature available on the subject, I am one of the very few (if not the only) researchers who have used Skrébitsky as a source.</span>
+            </p>
+            <div id="page_6" class="page-normal" epub:type="pagebreak" title="6"></div>
+            <p>
+                <span id="dtb164">I did have access to a single first-hand source - the information I use to describe Haüy's pedagogical methods was, in part, gleaned from his own Essai sur l'Education
+                    des Aveugles.</span>
+            </p>
+            <p>
+                <span id="dtb165">I have hunted for sources in museums and archives where most of the material available was in printed form. </span>
+                <span id="dtb166">The few hand-written documents in existence are in the possession of the Association Valentin Haüy in Paris.</span>
+            </p>
+            <p>
+                <span id="dtb167">Most of the documents I have used for this paper are in the library at the Danish Museum of the Blind, which is the only Nordic library that possesses a copy of Valentin
+                    Haüy's Essai de l'Education des Jeunes Aveugles, together with the Institution des Jeunes Aveugles' annual reports. </span>
+                <span id="dtb168">One of these reports merits special attention since it contains a relatively early biographical article on Valentin Haüy written by the director of the institute, Dr P-A
+                    Dufau. </span>
+                <span id="dtb169">The report is dated 1852, when the institute transferred to its present location in the Boulevard des Invalides. </span>
+                <span id="dtb170">The article in question was written in 1844 and was published separately. </span>
+                <span id="dtb171">Dufau's main source is a letter written by Valentin Haüy to his son.</span>
+            </p>
+            <p>
+                <span id="dtb172">Paul Henri, head of the Association Valentin Haüy in the 1950s, in his biography of Louis Braille (The Life and Work of Louis Braille 1809-1852) dedicated an ample
+                    section to Valentin Haüy and his pioneering work in the field of education for the blind. </span>
+                <span id="dtb173">His biography first appeared in France in the 1950s in a Braille version and was later, on the decision of the World Blind Union, translated into English and published by
+                    the South African National Council for the Blind in 1987. </span>
+                <span id="dtb174">According to Didier-Weygand (2000), Henri also published a separate biography of Valentin Haüy (Paris, 1984), but unfortunately this information reached me only when the
+                    present paper was to all intents and purposes completed.</span>
+            </p>
+            <p>
+                <span id="dtb175">Existing literature tends to ignore Valentin Haüy's stay in St Petersburg. so I have paid particular attention to that period in his life. </span>
+                <span id="dtb176">A valuable source was the Russian ophtalmologist Alexander Skrébitsky's little publication, Valentin Haüy à St. </span>
+                <span id="dtb177">Petersbourg (1884). </span>
+                <span id="dtb178">Skrébitsky can be said to have rediscovered Haüy in Russia during his own attempts to improve conditions for the blind. </span>
+                <span id="dtb179">Haüy's institute for the blind in St Petersburg had by then been closed and forgotten for many years, but Skrébitsky found material in its archives on which he based his
+                    book. </span>
+                <span id="dtb180">There was, for example, a box full of documents dating from the period 1807-1809, but only a few documents from the latter part of Haüy's stay in Russia. </span>
+                <span id="d910e939">
+                    <span id="dtb181">Skrébitsky managed to smuggle the box out of Russia and donated it to the Valentin Haüy Museum in Paris where it is still kept </span>
+                    <a id="dtb182" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_4">4</a>
+                    <span id="dtb183">. </span>
+                </span>
+                <span id="dtb184">I have been able to ascertain that this information is correct, but have not had the opportunity to consult these documents personally. </span>
+                <span id="dtb185">I trust that Skrébitsky's quotations from them are accurate.</span>
+            </p>
+            <p>
+                <span id="dtb186">The French historian Zina Weygand published a booklet entitled Les Temps des Fondateurs 1784-1844 for the second Congress on the history of the blind in Paris in 1998. </span>
+                <span id="dtb187">Her booklet is interesting as she had access to the archives of the Institution des Jeunes Aveugles (INJA) created by Valentin Haüy, the Bibliothèque National de France,
+                    the Bibliothèque Association Valentin Haüy, as well as those of the Archive du C.N.H.O. des Quinze-Vingt. </span>
+                <span id="dtb188">Her booklet is only a foretaste of her doctoral thesis, La Cécité et les Aveugles dans la Société Française: Représentations et Institution du Moyen Âge aux Premières
+                    Années du XIX Siècle, published in March 2000. </span>
+                <span id="dtb189">Weygand married shortly after the Paris Congress and now uses a double surname, Didier-Weygand. </span>
+                <span id="dtb190">Her sources include documents from archives, press cuttings and documents and letters written by Haüy himself. </span>
+                <span id="dtb191">She is the only researcher to have made use of the minutes kept by the various revolutionary committees in Paris during the 1790s. </span>
+                <span id="dtb192">She does not, however, write about Haüy's years in Russia.</span>
+            </p>
+            <div id="page_7" class="page-normal" epub:type="pagebreak" title="7"></div>
+            <p>
+                <span id="dtb193">To illustrate Haüy's influence on the development of education for the blind in other countries, I have chosen D.G. </span>
+                <span id="dtb194">Pritchard's Education and the Handicapped 1760-1960 (1963) as my main source since it is considered a standard work. </span>
+                <span id="dtb195">My sources on the work of pioneers in the education of the blind in Sweden are O.E. </span>
+                <span id="dtb196">Borg's Minnen från den svenska blindundervisningens <span id="d910e1000" class="num-word">70-års</span> jubileum den 21 maj 1883, Kjell-åke Johanssons research report Om
+                    blindundervisningen i Sverige från 1809 (1974) and Staffan Förhammar's doctoral thesis Från tärande till närande (1991).</span>
+            </p>
+            <p>
+                <span id="dtb197">I have also consulted press articles, amongst them Marlene Jantsch's article on Maria Theresia von Paradis, in the Wiener Medizinische Wochenschrift 47/1955.</span>
+            </p>
+        </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
@@ -107,1185 +107,1187 @@
         <link rel="prev" href="C00000-05-chapter.xhtml" />
         <link rel="next" href="C00000-07-rearnotes.xhtml" />
     </head>
-    <body id="d910e1012" epub:type="bodymatter chapter">
-        <h1 id="d910e1014">3. Valentin Haüy</h1>
-        <section id="d910e1023">
-            <h2 id="d910e1025">3.1 Introduction</h2>
-            <p>
-                <span id="dtb201">Special education for the deaf, the visually handicapped and the disabled has its roots in the France of the Enlightenment, a period of growing interest in the
-                    creation of organised education for the handicapped. </span>
-                <span id="d910e1036">
-                    <span id="dtb202">In 1760, the abbé l'épée founded the first school for the deaf, where his educational methods were based on the teaching of sign language </span>
-                    <a id="dtb203" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_5">5</a>
-                    <span id="dtb204">. </span>
-                </span>
-                <span id="d910e1048">
-                    <span id="dtb205">Interest in education methods for the disabled began to develop seriously in the early years of the 19th century </span>
-                    <a id="dtb206" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_6">6</a>
-                    <span id="dtb207">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="d910e1063">
-                    <span id="dtb208">The debate on the social value of the handicapped and their learning capacity began with John Locke (1632-1704) and his essay "The Molyneux Problem," included in
-                        "An Essay Concerning Human Understanding" </span>
-                    <a id="dtb209" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_7">7</a>
-                    <span id="dtb210">. </span>
-                </span>
-                <span id="dtb211">Locke received a letter from William Molyneux, an Irishman, dated 2nd March 1693, in which the following question was posed: "If a person who was born blind, and who
-                    has learnt to distinguish by touch between a cube and a sphere regains vision after an operation, will he then be able to distinguish the cube from the sphere by sight alone?" </span>
-                <span id="d910e1078">
-                    <a id="dtb212" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_8">8</a>
-                    <span id="dtb213">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb214">Locke had a great influence on the French philosophers of the Enlightenment, and the famous debate on the "Molyneux problem" inspired the French philosopher Denis
-                    Diderot (1713-1784) to make contact with blind people and later publish his experiences in a pamphlet, Lettre sur les Aveugles pour Ceux qui voient (A Letter to the Blind for Those
-                    Who Can See). </span>
-                <span id="dtb215">His letter served several purposes. </span>
-                <span id="dtb216">On the one hand, Diderot exposed a fraud which had taken place in the drawing-room of the scientist S.A. </span>
-                <span id="d910e1099">
-                    <span id="dtb217">Réaumur , while on the other he made a number of observations which were a radical criticism of the conventional ideas of the time </span>
-                    <a id="dtb218" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_9">9</a>
-                    <span id="dtb219">. </span>
-                </span>
-                <span id="dtb220">The fraud in question consisted of a performance by a girl who claimed to be blind in Réaumur's drawing-room during which she played, sang and answered a series of
-                    general knowledge questions (for example, the length of certain rivers, the names of European cities, etc.). </span>
-                <span id="dtb221">Diderot unmasked this humbug, but also pointed out that fraudulent performances were unnecessary, since the blind could in fact be educated. </span>
-                <span id="dtb222">As an example of this, he mentioned the blind English mathematician Nicholas Saunderson. </span>
-                <span id="d910e1121">
-                    <span id="dtb223">In the second half of his letter, Diderot has Saunderson express, in an imaginary dialogue, his own atheistic philosophy of life, for which Diderot paid with a
-                        brief sojourn in prison </span>
-                    <a id="dtb224" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_10">10</a>
-                    <span id="dtb225">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb226">Diderot's letter made the bourgeoisie of the time aware that the blind could in fact be educated. </span>
-                <span id="d910e1139">
-                    <span id="dtb227">He went on to found a philanthrophic society in 1780 - the Société Philanthropique </span>
-                    <a id="dtb228" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_11">11</a>
-                    <span id="dtb229">, which opened up homes for the blind where they were taught handicrafts. </span>
-                </span>
-                <span id="d910e1151">
-                    <span id="dtb230">These "homes for the blind" -"Maisons des Enfans-Aveugles"- took in blind persons between the ages of 20 and 25 </span>
-                    <a id="dtb231" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_12">12</a>
-                    <span id="dtb232">.</span>
-                </span>
-            </p>
-            <div id="page_8" class="page-normal" epub:type="pagebreak" title="8"></div>
-            <p>
-                <span id="dtb233">With the support of the Société Philanthropique,Valentin Haüy founded the first special school for blind children and adolescents in 1784.</span>
-            </p>
-            <p>
-                <span id="d910e1176">
-                    <span id="dtb234">Diderot himself had a blind pupil, Mélanie de Salignac (1741-1763), who was his friend Sophie Volland's niece </span>
-                    <a id="dtb235" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_13">13</a>
-                    <span id="dtb236">. </span>
-                </span>
-                <span id="dtb237">He wrote about her in Addition de Lettre sur les Aveugles. </span>
-                <span id="dtb238">Salignac was mainly taught, however, by her mother. </span>
-                <span id="dtb239">She could read and write and, what is particularly interesting, she wrote in raised print, which Haüy then experimented with on a larger scale.</span>
-            </p>
-        </section>
-        <section id="d910e1199">
-            <h2 id="d910e1201">3.2 Biographical background</h2>
-            <p>
-                <span id="dtb241">Valentin Haüy was born on 13th November 1745 in Saint-Just en Chaussé (Picardy), a small village approximately 35 km east of Paris. </span>
-                <span id="dtb242">His father was a weaver. </span>
-                <span id="d910e1215">
-                    <span id="dtb243">Haüy's elder brother, the abbé René Just Haüy (1743-1822), was the pioneer of crystallography (the science of the structure, forms and property of crystals) and
-                        played an important role in the introduction of the metric system </span>
-                    <a id="dtb244" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_14">14</a>
-                    <span id="dtb245">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb246">In 1751, the family took up residence in Paris and the two brothers began to attend a school run by a Catholic order. </span>
-                <span id="dtb247">Later, both of them studied at the Sorbonne; Valentin studied Latin, Greek and Hebrew and was said to be fluent in about ten modern languages. </span>
-                <span id="dtb248">He earned a living as a translator of private and public documents and was soon able to boast the title of Royal Interpreter. </span>
-                <span id="dtb249">He was also interpreter to the city council of Paris and the Admiralty. </span>
-                <span id="dtb250">Before his appointment as royal interpreter he had become senior master in a secondary school. </span>
-                <span id="d910e1246">
-                    <span id="dtb251">He later became a member of the Bureau Académique des écritures, founded by Louis XVI, probably because he had invented a method of deciphering secret codes and
-                        military code systems </span>
-                    <a id="dtb252" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_15">15</a>
-                    <span id="dtb253">. </span>
-                </span>
-                <span id="dtb254">In 1771, the French police began to take an interest in deciphering codes, and during the following ten years, Valentin Haüy worked for the secret police, where his
-                    task was to investigate all foreign correspondence carried by the French postal service and to decipher secret documents. </span>
-                <span id="dtb255">He continued these activities under the various revolutionary governments in the latter part of the century.</span>
-            </p>
-            <p>
-                <span id="dtb256">Haüy was also interested in the education of the deaf. </span>
-                <span id="d910e1270">
-                    <span id="dtb257">He is said to have been actively involved in the teaching of deaf pupils and to have worked from time to time with the abbé l'épée </span>
-                    <a id="dtb258" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_16">16</a>
-                    <span id="dtb259">. </span>
-                </span>
-                <span id="d910e1282">
-                    <span id="dtb260">We can assume that his interest in the handicapped had already been aroused in 1771 when he visited one of the public performances given by the abbé's deaf pupils </span>
-                    <a id="dtb261" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_17">17</a>
-                    <span id="dtb262">.</span>
-                </span>
-            </p>
-        </section>
-        <section id="d910e1296">
-            <h2 id="d910e1298">3.3 The market in St Ovid's Square</h2>
-            <p>
-                <span id="d910e1306">
-                    <span id="dtb264">In a letter to his son, Haüy tells how during the annual market in St Ovid's Square in Paris, he saw blind musicians from the Quinze-Vingt asylum perform </span>
-                    <a id="dtb265" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_18">18</a>
-                    <span id="dtb266">. </span>
-                </span>
-                <span id="dtb267">He was sitting at a café when he saw some very strange creatures fitted with huge paper spectacles and pointed hats with donkey's ears affixed to them. </span>
-                <span id="dtb268">Sheet music was placed upside down on the blind musicians' music stands while they banged, blew, and squeezed noises out of their worn-out instruments.</span>
-            </p>
-            <p>
-                <span id="dtb269">Haüy was shocked by the way the disabled musicians' wretchedness was exaggerated by their ridiculous outfits. </span>
-                <span id="dtb270">He was also upset by the callousness of the audience, who howled with laughter at this shambles of an orchestra. </span>
-                <span id="dtb271">Haüy did not see any reason to laugh at people just because they had a physical impediment.</span>
-            </p>
-            <div id="page_9" class="page-normal" epub:type="pagebreak" title="9"></div>
-            <p>
-                <span id="dtb272">From that day he decided to dedicate his life to improving the conditions of the blind.</span>
-            </p>
-            <p>
-                <span id="dtb273">In his letter, he reflects:</span>
-            </p>
-            <blockquote id="dtb274">
+    <body>
+        <section id="d910e1012" epub:type="bodymatter chapter">
+            <h1 id="d910e1014">3. Valentin Haüy</h1>
+            <section id="d910e1023">
+                <h2 id="d910e1025">3.1 Introduction</h2>
                 <p>
-                    <span id="dtb275">"We asked ourselves: does not a blind person recognise objects by their different shapes? </span>
-                    <span id="dtb276">Is he mistaken as to the value of a coin? </span>
-                    <span id="dtb277">Why should it be impossible for him to distinguish between a C and a G, or between an A and an F, if those letters were made easier to distinguish? </span>
-                    <span id="dtb278">We sometimes reflected on the use of this performance (...)</span>
-                </p>
-                <p>
-                    <span id="dtb279">We soon saw various examples that convinced us how useful it would be for the blind to have access to teaching methods which could increase their knowledge so
-                        that they would not have to wait for help or sometimes ask the sighted to help them, often to no avail"</span>
-                </p>
-            </blockquote>
-            <p>
-                <span id="d910e1379">
-                    <a id="dtb280" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_19">19</a>
-                    <span id="dtb281">.</span>
-                </span>
-            </p>
-        </section>
-        <section id="d910e1390">
-            <h2 id="d910e1392">3.4 Maria Theresia von Paradis (1733-1808)</h2>
-            <p>
-                <span id="dtb283">Maria Theresia von Paradis was a woman who had a significant influence on Haüy and his teaching methods. </span>
-                <span id="dtb284">They met in Paris in 1785 while Paradis was on a concert tour of Europe. </span>
-                <span id="dtb285">Weygand (1998) says that Haüy read an article in a Parisian newspaper informing the public that the blind child prodigy Mara Theresia von Paradis was in the city and
-                    decided to contact her. </span>
-                <span id="d910e1409">
-                    <span id="dtb286">Maria Theresia von Paradis was born in Vienna and became blind at about 4 years of age </span>
-                    <a id="dtb287" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_20">20</a>
-                    <span id="dtb288">. </span>
-                </span>
-                <span id="dtb289">Jantsch suggests that the girl's blindness had hysterical origins. </span>
-                <span id="dtb290">Her father was a well-to-do lawyer. </span>
-                <span id="dtb291">Maria Theresia was extremely musical and became a virtuoso on the piano; she had her own school in Vienna where she taught piano and singing. </span>
-                <span id="dtb292">Between 1784 and 1785, she toured Europe, playing at the courts of Paris, London, Brussels, Hanover and Berlin, and giving concerts in several other cities. </span>
-                <span id="dtb293">Mozart composed a concerto for piano and orchestra especially for her European tour and von Paradis also wrote her own music, using a system for writing musical notes
-                    which she had had specially invented. </span>
-            </p>
-            <p>
-                <span id="dtb294">Before von Paradis set off on her grand tour of Europe, she had relief maps made of the different countries and cities she was to visit. </span>
-                <span id="dtb295">On these maps, frontiers and rivers were embroidered in backstitch, while cities and towns were represented by different-sized buttons; large buttons for capitals,
-                    smaller buttons for smaller cities or towns. </span>
-                <span id="d910e1446">
-                    <span id="dtb296">Von Paradis had raised texts printed; a special printing press was made for her by Wolfgang Ritter von Kempelen </span>
-                    <a id="dtb297" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_21">21</a>
-                    <span id="dtb298">. </span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb299">Von Paradis corresponded with Johan Ludwig Weissenburg, who was also blind and who himself used raised maps and writing. </span>
-                <span id="dtb300">Their letters show that they discussed how raised pictures and maps could be made. </span>
-                <span id="dtb301">For mathematical calculations, Paradis used an arithmetic board made in England by Saunderson. </span>
-            </p>
-            <p>
-                <span id="d910e1473">
-                    <span id="dtb302">Haüy's meeting with Maria Theresia von Paradis gave him the inspiration and encouragement he so desperately needed at that time to develop an educational
-                        programme for blind children </span>
-                    <a id="dtb303" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_22">22</a>
-                    <span id="dtb304">. </span>
-                </span>
-                <span id="d910e1485">
-                    <span id="dtb305">He presented his plan, "Plan de l'Education à l'Usage des Aveugles," to the Philanthropic Society, which at that time sponsored twelve children from poor families </span>
-                    <a id="dtb306" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_23">23</a>
-                    <span id="dtb307">. </span>
-                </span>
-            </p>
-            <p>
-                <span id="d910e1501">
-                    <span id="dtb308">In his Essai sur l'Education des Enfans-Aveugles </span>
-                    <a id="dtb309" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_24">24</a>
-                    <span id="dtb310">, Haüy repeatedly mentions that several of the tools he recommended for the teaching of blind children had been used by Maria Theresia von Paradis. </span>
-                </span>
-            </p>
-            <div id="page_10" class="page-normal" epub:type="pagebreak" title="10"></div>
-        </section>
-        <section id="d910e1519">
-            <h2 id="d910e1521">3.5 Haüy's meeting with Lesueur and the founding of l'Institution des Jeunes Aveugles</h2>
-            <p>
-                <span id="d910e1529">
-                    <span id="dtb312">Haüy was convinced that the blind deserved a better life than begging and performing in market places </span>
-                    <a id="dtb313" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_25">25</a>
-                    <span id="dtb314">. </span>
-                </span>
-                <span id="dtb315">They ought to enjoy the same right to education and work as the sighted. </span>
-                <span id="dtb316">Not until thirteen years after the market in St Ovid's Square did he have an opportunity to demonstrate that the blind could be educated. </span>
-                <span id="dtb317">This occurred when he was invited to teach François Lesueur, or Le Sueur, as Didier-Weygand sometimes writes his name.</span>
-            </p>
-            <p>
-                <span id="d910e1553">
-                    <span id="dtb318">Haüy first met Lesueur, standing begging at the entrance to the church of Saint-Germain-des Prés </span>
-                    <a id="dtb319" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_26">26</a>
-                    <span id="dtb320">. </span>
-                </span>
-                <span id="d910e1565">
-                    <span id="dtb321">Lesueur was a professional beggar who supported himself, his parents and four siblings with the money he was given by churchgoers (since the Middle Ages, the
-                        Catholic Church had allowed the blind to beg outside churches) </span>
-                    <a id="dtb322" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_27">27</a>
-                    <span id="dtb323">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="d910e1580">
-                    <span id="dtb324">The story goes on to tell how Haüy, when he gave Lesueur some money, was told, "You thought you gave me a measly sou when in fact it was an écu " </span>
-                    <a id="dtb325" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_28">28</a>
-                    <span id="dtb326">. </span>
-                </span>
-                <span id="dtb327">From this incident Haüy immediately drew conclusions regarding the fine sense of touch the blind possess. </span>
-                <span id="dtb328">If we compare this version of their meeting with Haüy's own words in section 3.3, we can guess how the story originated.</span>
-            </p>
-            <p>
-                <span id="dtb329">Haüy started by teaching Lesueur good manners, grammatically correct speech and arithmetic. </span>
-                <span id="dtb330">Haüy's main interest, however, was teaching the blind to read. </span>
-                <span id="dtb331">He had wooden letters made so that Lesueur could learn the alphabet and later learn to read. </span>
-                <span id="dtb332">This was achieved by forming the letters into words in a wooden frame. </span>
-                <span id="dtb333">In a similar way, Lesueur learned the four arithmetical rules; in this case, wooden numbers were placed in different compartments in a frame. </span>
-                <span id="dtb334">A major problem proved to be a supply of books for Lesueur. </span>
-                <span id="dtb335">Haüy soon realised that his pupil could recognise raised letters, so he began to produce raised letters on waxed paper. </span>
-                <span id="dtb336">Haüy had started teaching Lesueur on 31st May 1784. </span>
-                <span id="d910e1626">
-                    <span id="dtb337">By September of the same year, he was able to announce his progress in an article in the Journal de Paris </span>
-                    <a id="dtb338" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_29">29</a>
-                    <span id="dtb339">. </span>
-                </span>
-                <span id="dtb340">On November 18th, both teacher and pupil appeared before the Académie de l'écriture. </span>
-                <span id="dtb341">It was common practice at that time for pupils to appear before the Academy and the Court, and not just "handicapped prodigies". </span>
-                <span id="d910e1645">
-                    <span id="dtb342">The Academy apparently fulfilled some kind of educational inspecting and authorising function </span>
-                    <a id="dtb343" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_30">30</a>
-                    <span id="dtb344">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb345">Lesueur could read, recognise countries on a map and identify raised numbers on cardboard. </span>
-                <span id="dtb346">This made Haüy's name as a teacher of the blind. </span>
-                <span id="d910e1667">
-                    <span id="dtb347">The Academy decided to recommend his methods of teaching the blind </span>
-                    <a id="dtb348" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_31">31</a>
-                    <span id="dtb349">. </span>
-                </span>
-                <span id="dtb350">Thanks to Haüy's brother René-Just, the French Academy of Science became interested in his teaching methods. </span>
-                <span id="dtb351">Four members of the Academy studied Haüy's methods and expressed their approval. </span>
-                <span id="d910e1686">
-                    <span id="dtb352">Their report was registered by the Academy on 16th February 1785 </span>
-                    <a id="dtb353" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_32">32</a>
-                    <span id="dtb354">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb355">In January 1785, Haüy became a member of the Société Philanthropique which also entrusted him with the teaching of their twelve blind protégés. </span>
-                <span id="d910e1704">
-                    <span id="dtb356">These were all young adults aged between 20 and 30 </span>
-                    <a id="dtb357" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_33">33</a>
-                    <span id="dtb358">. </span>
-                </span>
-                <span id="dtb359">Haüy could now rent a house in the Rue Coquillère where he taught his pupils. </span>
-                <span id="dtb360">A year later, when the number of pupils had increased, he moved into a house in the Rue Notre-Dame-des-Victoires, where the Société Philanthropique had its workshop
-                    for the blind, and so l'Institution des Jeunes Aveugles (the Institute for Blind Children ) was born. </span>
-                <span id="d910e1722">
-                    <span id="dtb361">The pupils who now arrived at the institute were young children </span>
-                    <a id="dtb362" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_34">34</a>
-                    <span id="dtb363">.</span>
-                </span>
-            </p>
-            <div id="page_11" class="page-normal" epub:type="pagebreak" title="11"></div>
-            <p>
-                <span id="dtb364">Twice a year the blind children performed before the Court. </span>
-                <span id="dtb365">Louis XVI was patron of the institute and also contributed economically to its upkeep. </span>
-                <span id="dtb366">In an appendix to Haüy's pamphlet, Essai sur l'éducation des Aveugles, there is a list of the first twelve pupils to perform at the Court.</span>
-            </p>
-            <p>
-                <span id="dtb367">Boys and girls alike attended the institute. </span>
-                <span id="dtb368">The blind children came from poor homes and were not charged for their tuition. </span>
-                <span id="dtb369">Haüy did, however, accept sighted children from well-to-do families who paid for their children's education. </span>
-                <span id="d910e1761">
-                    <span id="dtb370">Haüy believed that sighted and blind children should be educated together without restriction </span>
-                    <a id="dtb371" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_35">35</a>
-                    <span id="dtb372">.</span>
-                </span>
-            </p>
-        </section>
-        <section id="d910e1775">
-            <h2 id="d910e1777">3.6 Valentin Haüy's teaching methods</h2>
-            <p>
-                <span id="dtb374">Valentin Haüy's first and only pamphlet on his teaching methods was published in 1786 with the long title of Essai sur l'éducation des aveugles ou Exposé de différens
-                    moyens, vérifiés par l'expérience, pour les mettre en état de lire, à l'aide du tact, d'imprimer des livres dans lesquels ils puissent prendre des connaissances des langues,
-                    d'histoire, de la Géographie, de la Musique, &amp;c., d'exécuter différens travaux relatifs aux Métiers, &amp;c., Dédié au Roi, par M. </span>
-                <span id="dtb375">Haüy. </span>
-                <span id="dtb376">It was printed by Haüy's blind pupils. </span>
-                <span id="dtb377">Only the preface was set in normal type; the main text was set in the type created by Haüy for use with ink print or raised print. </span>
-                <span id="dtb378">It was dedicated to the French king, Louis XVI. </span>
-                <span id="dtb379">The title page reads, "Au Roi", followed by a brief preface dedicated to the king:</span>
-            </p>
-            <blockquote id="dtb380">
-                <p id="d910e1807" class="line">
-                    <span id="dtb381">"To the KING OF FRANCE</span>
-                </p>
-                <p id="d910e1813" class="line">
-                    <span id="dtb382">SIRE,</span>
-                </p>
-                <p>
-                    <span id="dtb383">THE Protection with which your Majesty honours distinguished Talents ascertains your Claim to their Reverence and Respect. </span>
-                    <span id="dtb384">But when their Productions have a Tendency to console the Miseries of suffering Humanity, they have still a more powerful Title to attract the attention of Louis
-                        the Beneficent. </span>
-                    <span id="dtb385">It was under the influence of Sentiments inspired by a Title so amiable, which is deeply engraven on all the Hearts of France, that I conceived the desire of
-                        presenting to your Majesty the Fruits of my Labours ; if they have any Value, they will owe it to the double Advantage of appearing under a Patronage so august, and of becoming
-                        Vehicles to the Bounty expected from Sovereign by the Young and unhappy, who have been early deprived of the Benefit of Light with all its numerous and important
-                        Resources.</span>
-                </p>
-                <p id="d910e1831" class="line">
-                    <span id="dtb386">I am, With the profoundest respect,</span>
-                </p>
-                <p id="d910e1837" class="line">
-                    <span id="dtb387">Sire,</span>
-                </p>
-                <p id="d910e1844" class="line">
-                    <span id="dtb388">Your Majesty’s most humble,</span>
-                </p>
-                <p id="d910e1850" class="line">
-                    <span id="dtb389">must obedient</span>
-                </p>
-                <p id="d910e1856" class="line">
-                    <span id="dtb390">and most faithful subject and Servant,</span>
-                </p>
-                <p id="d910e1862" class="line">
-                    <span id="dtb391">HAÙY".</span>
-                </p>
-            </blockquote>
-            <p>
-                <span id="dtb392">In his essay Haüy expounds his pedagogical theories and presents a programme of studies for blind children. </span>
-                <span id="dtb393">His basic premise was that the "unfortunate Blind," who until then had been deprived of education, could in fact be educated and ought therefore to be given the
-                    opportunity to attend school and learn a trade by which they could later make a living.</span>
-            </p>
-            <p>
-                <span id="dtb394">Each subject is dealt with in a short chapter. </span>
-                <span id="dtb395">Haüy gives simple, practical advice on teaching methods and on the production of material for use in object lessons and of a variety of teaching aids.</span>
-            </p>
-            <div id="page_12" class="page-normal" epub:type="pagebreak" title="12"></div>
-            <p>
-                <span id="dtb396">He lays particular stress on the methods to be used to teach blind children to read and write and on how to produce raised print books. </span>
-                <span id="dtb397">An entire chapter is dedicated to explaining how blind pupils can be trained as compositors. </span>
-                <span id="dtb398">He also attempts to demonstrate that those blind pupils who did learn some kind of handicraft (at Quinze-Vingt, for example) were able to earn their own living. </span>
-                <span id="dtb399">Haüy therefore recommends that teaching of the blind should include activities such as the production of walking sticks and hairnets, sewing, bookbinding, etc.</span>
-            </p>
-            <p>
-                <span id="dtb400">Haüy also insists that blind pupils should study history, geography and music. </span>
-                <span id="dtb401">In the chapter on the teaching of geography, he mentions Maria Theresia von Paradis and stresses the importance of tactile maps and the terrestrial globe to
-                    illustrate the concepts of countries, lakes, rivers, mountains, etc. </span>
-                <span id="d910e1914">
-                    <span id="dtb402">He goes on to describe the method of producing maps developed by von Paradis and Weissenburg </span>
-                    <a id="dtb403" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_36">36</a>
-                    <span id="dtb404">. </span>
-                </span>
-                <span id="d910e1926">
-                    <span id="dtb405">As for music and the possibility of a blind person's earning his living as a musician, Haüy points to von Paradis's success and her system of raised musical notes </span>
-                    <a id="dtb406" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_37">37</a>
-                    <span id="dtb407">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb408">When he touches on the teaching of mathematics, Haüy affirms that although he admires Saunderson and Weissenburg's "arithmetic boards", he firmly believes that blind
-                    and sighted children should be taught together and for this reason he does not agree with the use of special mathematical teaching aids for blind children. </span>
-                <span id="dtb409">Haüy does recognise that blind pupils may need some kind of assistance when drawing geometrical figures, for example, and had paper templates for this purpose.</span>
-            </p>
-            <p>
-                <span id="d910e1950">
-                    <span id="dtb410">Haüy's invention, a method of producing raised letters on paper with the types he had cast, was completely new </span>
-                    <a id="dtb411" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_38">38</a>
-                    <span id="dtb412">. </span>
-                </span>
-                <span id="dtb413">He now saw as his principle task to attempt to produce as many copies of books for the blind as possible. </span>
-                <span id="dtb414">He wanted every blind child to have his or her own collection of raised print books. </span>
-                <span id="dtb415">In time he designed and had made a printing press which could produce raised print and to which he added a device for dyeing the raised letters black. </span>
-                <span id="d910e1971">
-                    <span id="dtb416">The first two books printed by Haüy for his blind pupils were produced in this way </span>
-                    <a id="dtb417" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_39">39</a>
-                    <span id="dtb418">. </span>
-                </span>
-                <span id="dtb419">One was his own treatise on education for the blind: Essai sur l'Education des Enfans-Aveugles (1786); the other a historical review of the institute's first five
-                    years of existence entitled Notice Historique de l'Institution des Enfans-Aveugles (1791).</span>
-            </p>
-            <p>
-                <span id="dtb420">Haüy believed that his printing method would make it possible for the blind to print books not only for their own use but also for the sighted. </span>
-                <span id="dtb421">He dreamed of a time when his blind pupils would become teachers of sighted children; the blind teacher and the sighted pupils would read from the same book. </span>
-                <span id="dtb422">Haüy's method was, however, a form of printing, that is, it involved typographic composition, so to enable the blind to correspond with the sighted in a simpler
-                    fashion, Haüy designed a "writing board" on which the writer wrote with a steel pen which had an undivided nib. </span>
-                <span id="dtb423">His idea was that the blind person should write his letter by hand on the one side of a suitable type of paper. </span>
-                <span id="dtb424">This would produce raised letters on the other side of the paper, letters which the writer himself would be able to read by touch. </span>
-                <span id="d910e2006">
-                    <span id="dtb425">Unfortunately, his apparatus was not of much use to those who had never seen letters </span>
-                    <a id="dtb426" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_40">40</a>
-                    <span id="dtb427">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb428">The school in the Rue Victoires did more than provide its blind pupils with a basic education, it also taught them a useful trade. </span>
-                <span id="dtb429">Their teachers believed in the positive value of work. </span>
-                <span id="dtb430">The children spun thread, wove, knitted, made leather belts and hairnets, etc. </span>
-                <span id="dtb431">They produced raised print but also printed in ink. </span>
-                <span id="d910e2034">
-                    <span id="dtb432">Towards the end of his essay on the education of the blind, </span>
-                    <a id="dtb433" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_41">41</a>
-                    <span id="dtb434"> there are ten or so examples of the blind children's printing activities (invitation cards, announcements, invoices, prospectuses, etc.). </span>
-                </span>
-                <span id="dtb435">Although Haüy had raised scores made, he did not at first consider music to be anything more than an entertainment for the blind.</span>
-            </p>
-            <div id="page_13" class="page-normal" epub:type="pagebreak" title="13"></div>
-            <p>
-                <span id="d910e2056">
-                    <span id="dtb436">He changed his opinion later when he discovered that the blind could learn to play the organ and thus could be employed as church organists </span>
-                    <a id="dtb437" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_42">42</a>
-                    <span id="dtb438">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="d910e2071">
-                    <span id="dtb439">The aim behind Haüy's teaching methods was to enable his blind pupils to communicate satisfactorily with the sighted </span>
-                    <a id="dtb440" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_43">43</a>
-                    <span id="dtb441">. </span>
-                </span>
-                <span id="dtb442">He therefore rejected all writing systems for the blind which did not use the Roman alphabet. </span>
-                <span id="dtb443">He would probably never have approved of Braille's system.</span>
-            </p>
-            <p>
-                <span id="d910e2092">
-                    <span id="dtb444">At first, boys and girls were taught together in mixed classes, but some years later, after Haüy had been severely criticised for the co-educational organisation
-                        of his school, the sexes were segregated </span>
-                    <a id="dtb445" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_44">44</a>
-                    <span id="dtb446">.</span>
-                </span>
-            </p>
-            <p>
-                <span id="d910e2107">
-                    <span id="dtb447">Haüy's successor at the institute, Guillé, was himself severely criticised for his harsh methods of punishment </span>
-                    <a id="dtb448" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_45">45</a>
-                    <span id="dtb449">. </span>
-                </span>
-                <span id="dtb450">In the accusations made against Guillé, his severity was compared with Haüy's mild methods and his concern for his pupils. </span>
-                <span id="dtb451">It is not clear, however, whether the critics implied by this that Haüy never used corporal punishment.</span>
-            </p>
-        </section>
-        <section id="d910e2127">
-            <h2 id="d910e2129">3.7 The French Revolution</h2>
-            <p>
-                <span id="dtb453">Louis XVI was Haüy's patron and the institute's most important financial sponsor. </span>
-                <span id="dtb454">When the monarchy was overthrown in 1791, the Institute for the Blind came under the authority of the new revolutionary government. </span>
-                <span id="dtb455">Education at the institute, however, continued along the same lines as it had done under the monarchy. </span>
-                <span id="d910e2146">
-                    <span id="dtb456">The various revolutionary governments for their part believed that all forms of education should be free of charge and controlled by the State </span>
-                    <a id="dtb457" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_46">46</a>
-                    <span id="dtb458">. </span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb459">The National Convention issued a decree on 28th September 1791 which nationalised the Institute for the Blind. </span>
-                <span id="dtb460">The need to reduce financial costs was responsible for the fusion of the Institute for the Blind and L'épée's Institute for the Deaf. </span>
-                <span id="d910e2167">
-                    <span id="dtb461">The resulting institute was moved to a monastery </span>
-                    <a id="dtb462" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_47">47</a>
-                    <span id="dtb463">. </span>
-                </span>
-                <span id="dtb464">This fusion, however, was unsuccessful, and in 1794 the National Convention decided to separate the two schools once more. </span>
-                <span id="dtb465">Haüy played an important part in this decision. </span>
-                <span id="dtb466">He attacked l'épée's successor, Sicard, because he had criticised his teaching methods. </span>
-                <span id="dtb467">Haüy was at that time a member of one of the revolutionary committees in Paris and was able to have Sicard arrested (Didier Weygand). </span>
-                <span id="dtb468">Sicard was soon released, however, and two years later (1796) he had his revenge when he accused Haüy of belonging to an illegal secret society. </span>
-                <span id="dtb469">Haüy was arrested and spent a brief spell in prison. </span>
-            </p>
-            <p>
-                <span id="d910e2201">
-                    <span id="dtb470">After the break-up, the Institute for the Blind moved to a former convent at 34, Rue Denis, where it was renamed l'Institut National des Aveugles Travailleurs ,
-                        that is The National Institute for Blind Craftsmen </span>
-                    <a id="dtb471" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_48">48</a>
-                    <span id="dtb472">. </span>
-                </span>
-                <span id="dtb473">Coinciding with the move, the institute was reorganised and the pupils now had to contribute to the upkeep of the new, revolutionary France (28th July, 1795). </span>
-                <span id="dtb474">The blind pupils' first task was to make 86 purses. </span>
-                <span id="d910e2219">
-                    <span id="dtb475">At this point, the revolutionary committees began to debate whether institutes for the disabled should be classed as schools or asylums </span>
-                    <a id="dtb476" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_49">49</a>
-                    <span id="dtb477">. </span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb478">Haüy initially sided with the Revolution. </span>
-                <span id="d910e2237">
-                    <span id="dtb479">He was, as we said, an active member of one of the revolutionary committees </span>
-                    <a id="dtb480" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_50">50</a>
-                    <span id="dtb481">, and on 8th of June 1794, "the Day of Pure Reason", he did not hesitate to have his blind musicians appear on a mobile platform from which he, in revolutionary
-                        language, urged them to follow Robespierre, who was dressed as the high priest of Pure Reason </span>
-                    <a id="dtb482" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_51">51</a>
-                    <span id="dtb483">. </span>
-                </span>
-            </p>
-            <div id="page_14" class="page-normal" epub:type="pagebreak" title="14"></div>
-            <p>
-                <span id="dtb484">Under the monarchy, his blind pupils regularly appeared in public to demonstrate their progress and these performances continued during the revolutionary period. </span>
-                <span id="dtb485">Haüy's ability to adapt to the different régimes would later go against him, however. </span>
-                <span id="d910e2268">
-                    <span id="dtb486">During the Directorate, Haüy founded what was called a theophilanthropic cult with two other revolutionaries, La Revellère-Lepeaux and Chemin-Dupontè </span>
-                    <a id="dtb487" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_52">52</a>
-                    <span id="dtb488">. </span>
-                </span>
-                <span id="dtb489">This could be described as a development of the cult of pure reason in which the magistrate assumed the role of the priest. </span>
-                <span id="d910e2283">
-                    <span id="dtb490">The theophilanthropists substituted the head of the family for the priest; their philosophy was a mixture of theodicy and belief in the good individual </span>
-                    <a id="dtb491" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_53">53</a>
-                    <span id="dtb492">. </span>
-                </span>
-                <span id="dtb493">Haüy's successor as director of the institute (Guillé) was a strict Catholic who was horrified by Haüy's philosophical ideas. </span>
-                <span id="dtb494">He later accused Haüy of heresy (amongst other things) as one of his reasons for not permitting Haüy to visit the institute. </span>
-            </p>
-            <p>
-                <span id="dtb495">At the end of the revolutionary decade, the institute was bankrupt. </span>
-                <span id="dtb496">The State owed the institute <span id="d910e2310" class="num-with-space">30 000</span> francs, apart from nine months' salary to teachers and other staff. </span>
-                <span id="dtb497">Teachers and pupils alike starved and froze. </span>
-                <span id="dtb498">Haüy lodged a complaint with the consular government but this was rejected outright; no money was forthcoming. </span>
-                <span id="d910e2320">
-                    <span id="dtb499">His activities during the Reign of Terror and the Directorate spoke against him </span>
-                    <a id="dtb500" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_54">54</a>
-                    <span id="dtb501">. </span>
-                </span>
-                <span id="d910e2333">
-                    <span id="dtb502">On 14th March 1801, Napoleon Bonaparte, now First Consul, decided that the Institute for Blind Craftsmen should be integrated into the Quinze-Vingt Hospital, an
-                        asylum for elderly blind people which had existed since the end of the 13th Century </span>
-                    <a id="dtb503" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_55">55</a>
-                    <span id="dtb504">. </span>
-                </span>
-                <span id="dtb505">Napoleon furthermore forbade the theophilanthropists to practise their cult. </span>
-                <span id="dtb506">Teaching at the institute was now reduced to two hours a day; during the rest of the day the blind children worked with sighted adults in the Quinze-Vingt workshops. </span>
-                <span id="dtb507">Haüy was extremely affected and protested in three letters to the Minister of Interior Affairs (Lucien Bonaparte, one of Napoleon's brothers and Second Consul during
-                    the Second Consulate). </span>
-                <span id="d910e2354">
-                    <span id="dtb508">The minister answered that the State was responsible for the education of the blind; Haüy's role was simply to carry out the State's orders </span>
-                    <a id="dtb509" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_56">56</a>
-                    <span id="dtb510">. </span>
-                </span>
-                <span id="dtb511">The answer to the last of the letters (dated 12th February 1802) was Haüy's dismissal, although he was granted a pension of 2000 livres a year. </span>
-            </p>
-        </section>
-        <section id="d910e2371">
-            <h2 id="d910e2373">3.8 Musée des Aveugles</h2>
-            <p>
-                <span id="dtb513">In spite of this adversity, Haüy did not give up. </span>
-                <span id="d910e2384">
-                    <span id="dtb514">He was now assured of an annual income of 2000 livres, so it was not long before he founded a private institute for the blind which he called the Musée des
-                        Aveugles </span>
-                    <a id="dtb515" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_57">57</a>
-                    <span id="dtb516">. </span>
-                </span>
-                <span id="dtb517">He planned that the new institute should complement the National Institute for the Blind. </span>
-                <span id="dtb518">It was divided into two departments: one for pre-school children aged between four and seven years of age, the other for pupils over the age of sixteen who were
-                    taught a trade. </span>
-                <span id="dtb519">Haüy was thus a precursor of Fröbel as far as pre-school education is concerned. </span>
-                <span id="dtb520">The new institute fulfilled another of Haüy's dreams. </span>
-                <span id="dtb521">His blind adolescent pupils taught the sighted children who boarded in an annexe of the Musée des Aveugles. </span>
-                <span id="dtb522">In the long run, however, Haüy could not make ends meet and had to close the institute in 1806. </span>
-                <span id="dtb523">According to Weygand (1998), he simply did not have enough pupils.</span>
-            </p>
-            <p>
-                <span id="dtb524">Skrébitsky says that Haüy was very heavily in debt when he eventually arrived in St Petersburg. </span>
-                <span id="d910e2424">
-                    <span id="dtb525">A Maltese banker, amongst others, demanded payment which was deducted from his salary in Russia </span>
-                    <a id="dtb526" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_58">58</a>
-                    <span id="dtb527">.</span>
-                </span>
-            </p>
-            <div id="page_15" class="page-normal" epub:type="pagebreak" title="15"></div>
-        </section>
-        <section id="d910e2441">
-            <h2 id="d910e2443">3.9 Valentin Haüy in Russia</h2>
-            <section id="d910e2449">
-                <h3 id="d910e2451">3.9.1 An invitation from Alexander I</h3>
-                <p>
-                    <span id="dtb530">Word of Valentin Haüy's success soon spread throughout Europe. </span>
-                    <span id="d910e2462">
-                        <span id="dtb531">Several of the enlightened rulers were interested in acquiring his services </span>
-                        <a id="dtb532" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_59">59</a>
-                        <span id="dtb533">. </span>
+                    <span id="dtb201">Special education for the deaf, the visually handicapped and the disabled has its roots in the France of the Enlightenment, a period of growing interest in the
+                        creation of organised education for the handicapped. </span>
+                    <span id="d910e1036">
+                        <span id="dtb202">In 1760, the abbé l'épée founded the first school for the deaf, where his educational methods were based on the teaching of sign language </span>
+                        <a id="dtb203" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_5">5</a>
+                        <span id="dtb204">. </span>
                     </span>
-                    <span id="dtb534">Teaching of the blind had started both in Vienna and in Berlin and Haüy exported his typographic cases and material for use in object lessons to institutes for
-                        the blind in these two capitals and in other European cities. </span>
-                    <span id="dtb535">When his finances were so depleted that he had to close down the Musée des Aveugles, a number of welcome invitations arrived, one of them from Tsar Alexander I of
-                        Russia. </span>
-                    <span id="d910e2480">
-                        <span id="dtb536">The tsar, himself educated in the spirit of Enlightenment </span>
-                        <a id="dtb537" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_60">60</a>
-                        <span id="dtb538">, invited Haüy to come to Russia for the purpose of founding an institute for the blind </span>
-                        <a id="dtb539" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_61">61</a>
-                        <span id="dtb540">.</span>
+                    <span id="d910e1048">
+                        <span id="dtb205">Interest in education methods for the disabled began to develop seriously in the early years of the 19th century </span>
+                        <a id="dtb206" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_6">6</a>
+                        <span id="dtb207">.</span>
                     </span>
                 </p>
                 <p>
-                    <span id="dtb541">According to Skrébitsky (1884), Alexander I employed a number of agents who informed him of every new idea that could successfully be introduced into Russia. </span>
-                    <span id="dtb542">Negotiations with Haüy were arranged by General Hitrowo, and plans were drawn up for the creation of an institute for the blind in St Petersburg. </span>
-                    <span id="dtb543">These plans show that Haüy had no intention of remaining in St Petersburg for any length of time. </span>
-                    <span id="dtb544">The project basically involved:</span>
-                </p>
-                <p>
-                    <span id="dtb545">1. </span>
-                    <span id="dtb546">The supervision, in Paris, of the production of all the teaching material destined for use in the education and occupation of blind children and adults in Russia. </span>
-                    <span id="dtb547">Haüy promised to take with him to Russia educational material such as letters and numbers for reading, counting and printing, maps, writing boards, etc.</span>
-                </p>
-                <p>
-                    <span id="dtb548">2. </span>
-                    <span id="dtb549">Haüy would travel to Russia the following Spring (1804) and remain there for about a year, accompanied by one of his blind pupils who had been taught by his
-                        methods. </span>
-                    <span id="dtb550">Haüy believed that his visit would bring success to the new institute and the ideas behind it and that it would encourage competition amongst the young
-                        Russians.</span>
-                </p>
-                <p>
-                    <span id="dtb551">3. </span>
-                    <span id="d910e2544">
-                        <span id="dtb552">Haüy, whose idea the project was, agreed to teach his methods faithfully to the person appointed by His Imperial Highness Alexander I to direct the St
-                            Petersburg Institute for the Blind </span>
-                        <a id="dtb553" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_62">62</a>
-                        <span id="dtb554">.</span>
+                    <span id="d910e1063">
+                        <span id="dtb208">The debate on the social value of the handicapped and their learning capacity began with John Locke (1632-1704) and his essay "The Molyneux Problem," included in
+                            "An Essay Concerning Human Understanding" </span>
+                        <a id="dtb209" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_7">7</a>
+                        <span id="dtb210">. </span>
+                    </span>
+                    <span id="dtb211">Locke received a letter from William Molyneux, an Irishman, dated 2nd March 1693, in which the following question was posed: "If a person who was born blind, and who
+                        has learnt to distinguish by touch between a cube and a sphere regains vision after an operation, will he then be able to distinguish the cube from the sphere by sight alone?" </span>
+                    <span id="d910e1078">
+                        <a id="dtb212" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_8">8</a>
+                        <span id="dtb213">.</span>
                     </span>
                 </p>
                 <p>
-                    <span id="dtb555">According to Skrébitsky, the Russian government asked Haüy's advice on the personal qualities and qualifications required of the new director of the St Petersburg
-                        institute for the blind, and on the economic compensation Haüy was willing to accept to take on the responsibility of setting up the institute. </span>
-                    <span id="dtb556">The Russian government also wanted to know how much the project would cost. </span>
-                    <span id="dtb557">As to the necessary qualities and qualifications of the director of the institute, Haüy (according to Skrébitsky) would have answered that this person should be
-                        selected from amongst those teachers who had a good knowledge of Russian and French and, if possible, German. </span>
-                    <span id="dtb558">The Director must also have an elementary knowledge of practical activities such as spinning, knitting, the making of hairnets, different kinds of weaving, etc. </span>
-                    <span id="dtb559">Haüy furthermore pointed out that the director must be familiar with the art of printing if he was to fulfil his task. </span>
-                    <span id="dtb560">Only an amateur's knowledge of music was required, however. </span>
-                    <span id="dtb561">Haüy added that apart from these basic qualifications, the director must have a good head on his shoulders, be gentle and patient and have a love for mankind in
-                        general.</span>
+                    <span id="dtb214">Locke had a great influence on the French philosophers of the Enlightenment, and the famous debate on the "Molyneux problem" inspired the French philosopher Denis
+                        Diderot (1713-1784) to make contact with blind people and later publish his experiences in a pamphlet, Lettre sur les Aveugles pour Ceux qui voient (A Letter to the Blind for Those
+                        Who Can See). </span>
+                    <span id="dtb215">His letter served several purposes. </span>
+                    <span id="dtb216">On the one hand, Diderot exposed a fraud which had taken place in the drawing-room of the scientist S.A. </span>
+                    <span id="d910e1099">
+                        <span id="dtb217">Réaumur , while on the other he made a number of observations which were a radical criticism of the conventional ideas of the time </span>
+                        <a id="dtb218" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_9">9</a>
+                        <span id="dtb219">. </span>
+                    </span>
+                    <span id="dtb220">The fraud in question consisted of a performance by a girl who claimed to be blind in Réaumur's drawing-room during which she played, sang and answered a series of
+                        general knowledge questions (for example, the length of certain rivers, the names of European cities, etc.). </span>
+                    <span id="dtb221">Diderot unmasked this humbug, but also pointed out that fraudulent performances were unnecessary, since the blind could in fact be educated. </span>
+                    <span id="dtb222">As an example of this, he mentioned the blind English mathematician Nicholas Saunderson. </span>
+                    <span id="d910e1121">
+                        <span id="dtb223">In the second half of his letter, Diderot has Saunderson express, in an imaginary dialogue, his own atheistic philosophy of life, for which Diderot paid with a
+                            brief sojourn in prison </span>
+                        <a id="dtb224" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_10">10</a>
+                        <span id="dtb225">.</span>
+                    </span>
                 </p>
                 <p>
-                    <span id="dtb562">Haüy asked his imperial highness for an annual salary of at least <span id="d910e2586" class="num-with-space">40 000</span> roubles, of which half would be paid
-                        in advance when Haüy began his work. </span>
-                    <span id="dtb563">He also asked the crown to provide, at no cost to himself, a furnished house, light and fuel.</span>
+                    <span id="dtb226">Diderot's letter made the bourgeoisie of the time aware that the blind could in fact be educated. </span>
+                    <span id="d910e1139">
+                        <span id="dtb227">He went on to found a philanthrophic society in 1780 - the Société Philanthropique </span>
+                        <a id="dtb228" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_11">11</a>
+                        <span id="dtb229">, which opened up homes for the blind where they were taught handicrafts. </span>
+                    </span>
+                    <span id="d910e1151">
+                        <span id="dtb230">These "homes for the blind" -"Maisons des Enfans-Aveugles"- took in blind persons between the ages of 20 and 25 </span>
+                        <a id="dtb231" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_12">12</a>
+                        <span id="dtb232">.</span>
+                    </span>
                 </p>
-                <div id="page_16" class="page-normal" epub:type="pagebreak" title="16"></div>
+                <div id="page_8" class="page-normal" epub:type="pagebreak" title="8"></div>
                 <p>
-                    <span id="dtb564">Finally, he asked for <span id="d910e2601" class="num-with-space">2 000</span> roubles in advance, as travel allowance for himself and his blind pupil. </span>
-                    <span id="dtb565">Haüy did not ask for travel allowances for his wife and son, who accompanied him to Russia. </span>
-                    <span id="dtb566">He estimated the costs of inventories, including teaching material such as maps and a globe, at <span id="d910e2610" class="num-with-space">4 500</span> francs
-                        and the annual operating costs, including salaries, at <span id="d910e2613" class="num-with-space">54 700</span> francs. </span>
-                    <span id="dtb567">The institute should be staffed by three teachers, one of them a music teacher, and a manager for the printing works.</span>
+                    <span id="dtb233">With the support of the Société Philanthropique,Valentin Haüy founded the first special school for blind children and adolescents in 1784.</span>
                 </p>
                 <p>
-                    <span id="dtb568">Haüy estimated that costs would decrease as the pupils progressed in their activities. </span>
-                    <span id="dtb569">This he based on his experience in Paris where his pupils, once they had acquired a certain degree of skill in handicrafts and printing were able to make a profit
-                        for the institute. </span>
-                    <span id="dtb570">Haüy was convinced that his experience in Paris could be transferred to St Petersburg, which shows how little he knew about the country he was about to
-                        visit.</span>
+                    <span id="d910e1176">
+                        <span id="dtb234">Diderot himself had a blind pupil, Mélanie de Salignac (1741-1763), who was his friend Sophie Volland's niece </span>
+                        <a id="dtb235" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_13">13</a>
+                        <span id="dtb236">. </span>
+                    </span>
+                    <span id="dtb237">He wrote about her in Addition de Lettre sur les Aveugles. </span>
+                    <span id="dtb238">Salignac was mainly taught, however, by her mother. </span>
+                    <span id="dtb239">She could read and write and, what is particularly interesting, she wrote in raised print, which Haüy then experimented with on a larger scale.</span>
                 </p>
             </section>
-            <section id="d910e2634">
-                <h3 id="d910e2636">3.9.2 Berlin</h3>
+            <section id="d910e1199">
+                <h2 id="d910e1201">3.2 Biographical background</h2>
                 <p>
-                    <span id="dtb572">Haüy made a stop in Berlin en route to Russia in 1806. </span>
-                    <span id="dtb573">He had already received a request from the king of Prussia who wondered if Haüy would be interested in founding a school for the blind in Berlin. </span>
-                    <span id="d910e2650">
-                        <span id="dtb574">In Prussia initiatives had already been taken in the 1780s to gain State control of all educational activities </span>
-                        <a id="dtb575" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_63">63</a>
-                        <span id="dtb576">. </span>
-                    </span>
-                    <span id="dtb577">King Frederick William III introduced Haüy to professor Johan August Zeune (1778-1853), who was already engaged in teaching blind children. </span>
-                    <span id="d910e2665">
-                        <span id="dtb578">Haüy and Zeune together designed a curriculum for an institute for the blind in Berlin </span>
-                        <a id="dtb579" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_64">64</a>
-                        <span id="dtb580">. </span>
-                    </span>
-                    <span id="dtb581">Professor Zeune later became the director of the institute. </span>
-                    <span id="d910e2681">
-                        <span id="dtb582">In Berlin as in Paris attempts were made to fulfil an important pedagogical objective: the combination of a theoretical-humanistic education and practical
-                            activities </span>
-                        <a id="dtb583" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_65">65</a>
-                        <span id="dtb584">. </span>
-                    </span>
-                    <span id="d910e2693">
-                        <span id="dtb585">The battle of Jena and Auerstedt delayed Haüy's departure for St Petersburg, but in spite of this delay, he took time during the journey from Berlin to make a
-                            detour to Mitau in Kurland (today Jelgava in Latvia), where the Bourbon pretender to the French throne, Louis XVIII, was living in exile </span>
-                        <a id="dtb586" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_66">66</a>
-                        <span id="dtb587">. </span>
-                    </span>
-                    <span id="dtb588">Haüy paid his respects to Louis XVIII, who assured him of his support when he returned to France.</span>
-                </p>
-            </section>
-            <section id="d910e2710">
-                <h3 id="d910e2712">3.9.3 In St Petersburg</h3>
-                <p>
-                    <span id="dtb590">Haüy arrived in St Petersburg on September 9th 1806, and five days later sent a letter to the Tsar in which he sought an audience for himself and his
-                        seventeen-year-old blind pupil. </span>
-                    <span id="dtb591">He wrote that he thought the Tsar would be interested in meeting a blind person who was not only skilled in a handicraft but could also read and write and was
-                        well-versed in academic subjects such as history and geography. </span>
-                    <span id="d910e2726">
-                        <span id="dtb592">Haüy also wished to demonstrate an invention of his, the "advanced telegraph" </span>
-                        <a id="dtb593" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_67">67</a>
-                        <span id="dtb594">. </span>
-                    </span>
-                    <span id="dtb595">Skrébitsky states that he was unable to find any sources indicating that the Tsar actually received Haüy.</span>
-                </p>
-                <p>
-                    <span id="dtb596">Haüy's financial problems increased since none of the promises he had been given of compensation, a house, etc., were fulfilled. </span>
-                    <span id="dtb597">On 11th October 1806, he wrote a petition to the Tsar in which he set out his complaints. </span>
-                    <span id="d910e2750">
-                        <span id="dtb598">Skrébitsky says that he has found the letter in question and that it had a note in the margin (with a signature which probably belonged to the Minister of the
-                            General Education, Count Zawadowsky) which read, "The Tsar ordered this bill to be paid, premises to be found for the institute and a director who would learn Haüy's
-                            teaching methods to be selected and appointed to the institute" </span>
-                        <a id="dtb599" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_68">68</a>
-                        <span id="dtb600">. </span>
-                    </span>
-                    <span id="dtb601">Eight days after Haüy presented his petition, the money he had been promised was paid.</span>
-                </p>
-                <div id="page_17" class="page-normal" epub:type="pagebreak" title="17"></div>
-                <p>
-                    <span id="dtb602">The person who became head of the new institute for the blind was a certain Bouchoueff, who taught at a school in St Petersburg and claimed he was sufficiently
-                        fluent in French to be able to converse with Haüy and learn his pedagogical ideas. </span>
-                    <span id="dtb603">Bouchoueff was to live in Haüy's house. </span>
-                    <span id="dtb604">A report from the ministry dated 10th March 1807 shows that Haüy employed two assistants to work with Bouchoueff and himself. </span>
-                    <span id="dtb605">Fournier, Haüy's blind pupil, helped to instruct these assistants. </span>
-                    <span id="dtb606">Haüy invited public officials and members of the Russian Academy of Science to be present during Fournier's lectures, hoping to enlist their support. </span>
-                    <span id="dtb607">However, there were still no blind pupils. </span>
-                    <span id="dtb608">Haüy was told that the lack of pupils arose from the fact that there were no blind people in Russia. </span>
-                    <span id="dtb609">To this, Haüy replied:</span>
-                </p>
-                <blockquote id="dtb610">
-                    <p>
-                        <span id="dtb611">"If no blind people are to be seen on the streets, this is because the head of the family keeps them at home and because orphans and the children of imperial
-                            serfs are placed in asylums. </span>
-                        <span id="dtb612">It was not long before events proved my assumption to be correct, not to mention the blind beggars who had escaped the surveillance of the police and to whom
-                            I hastened to give alms. </span>
-                        <span id="dtb613">I would gladly have quadrupled the alms had they consented to regard the money as a daily wage in exchange for their work."</span>
-                    </p>
-                </blockquote>
-                <p>
-                    <span id="d910e2815">
-                        <a id="dtb614" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_69">69</a>
-                        <span id="dtb615">.</span>
+                    <span id="dtb241">Valentin Haüy was born on 13th November 1745 in Saint-Just en Chaussé (Picardy), a small village approximately 35 km east of Paris. </span>
+                    <span id="dtb242">His father was a weaver. </span>
+                    <span id="d910e1215">
+                        <span id="dtb243">Haüy's elder brother, the abbé René Just Haüy (1743-1822), was the pioneer of crystallography (the science of the structure, forms and property of crystals) and
+                            played an important role in the introduction of the metric system </span>
+                        <a id="dtb244" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_14">14</a>
+                        <span id="dtb245">.</span>
                     </span>
                 </p>
                 <p>
-                    <span id="dtb616">At this time, St Petersburg was a town with a multicultural population. </span>
-                    <span id="dtb617">There were many families of French origin; French was, in fact, the language used by the educated classes; reviews and newspapers were published in French. </span>
-                    <span id="dtb618">In his quest for pupils, Haüy placed advertisements in Le Lycée, a review, and in the daily Gazette de Petersbourg. </span>
-                    <span id="dtb619">These advertisements brought him two new pupils, both of foreign extraction.</span>
-                </p>
-                <p>
-                    <span id="dtb620">After some time, a Russian woman came to Haüy asking him to help her blind son who was an inmate of the asylum in Smolny . </span>
-                    <span id="dtb621">Haüy went to Smolny where he found several blind children living with the aged and the handicapped inmates. </span>
-                    <span id="dtb622">He took the son of the woman who had asked for his help back to St Petersburg with him and asked the authorities for permission to teach the other blind children
-                        in Smolny. </span>
-                    <span id="dtb623">The children were to be picked up by coach, in twos, and later returned to the asylum. </span>
-                    <span id="dtb624">Haüy himself would undertake to teach the boys, while his wife would teach the little girls. </span>
-                    <span id="dtb625">The director of the Smolny asylum, however, refused to give his permission. </span>
-                    <span id="dtb626">Haüy then sent a written request to the "Committee for General Beneficence" and later to the "Civil Governor", who promised to grant Haüy's request as soon as he
-                        found time to do so. </span>
-                    <span id="dtb627">He never had, however, any spare time. </span>
-                    <span id="dtb628">In the same document (dated 10th March 1807), Haüy also complained about his cramped lodgings which made it impossible for him to take in more than one blind
-                        pupil at a time. </span>
-                    <span id="dtb629">His other pupil, from Moscow, had to lodge elsewhere in the town. </span>
-                    <span id="dtb630">Haüy asked the authorities to provide him with the house he had been promised to enable him to establish his school under more suitable conditions. </span>
-                    <span id="d910e2877">
-                        <span id="dtb631">In his letter Haüy also mentioned his two assistants and praised Bouchoueff, but complained about the latter's " weak health, which permitted him to dedicate
-                            only half-days to studies which required at least a year of continuous dedication" </span>
-                        <a id="dtb632" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_70">70</a>
-                        <span id="dtb633">.</span>
+                    <span id="dtb246">In 1751, the family took up residence in Paris and the two brothers began to attend a school run by a Catholic order. </span>
+                    <span id="dtb247">Later, both of them studied at the Sorbonne; Valentin studied Latin, Greek and Hebrew and was said to be fluent in about ten modern languages. </span>
+                    <span id="dtb248">He earned a living as a translator of private and public documents and was soon able to boast the title of Royal Interpreter. </span>
+                    <span id="dtb249">He was also interpreter to the city council of Paris and the Admiralty. </span>
+                    <span id="dtb250">Before his appointment as royal interpreter he had become senior master in a secondary school. </span>
+                    <span id="d910e1246">
+                        <span id="dtb251">He later became a member of the Bureau Académique des écritures, founded by Louis XVI, probably because he had invented a method of deciphering secret codes and
+                            military code systems </span>
+                        <a id="dtb252" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_15">15</a>
+                        <span id="dtb253">. </span>
                     </span>
+                    <span id="dtb254">In 1771, the French police began to take an interest in deciphering codes, and during the following ten years, Valentin Haüy worked for the secret police, where his
+                        task was to investigate all foreign correspondence carried by the French postal service and to decipher secret documents. </span>
+                    <span id="dtb255">He continued these activities under the various revolutionary governments in the latter part of the century.</span>
                 </p>
                 <p>
-                    <span id="dtb634">Was it for tactical reasons that Haüy praised Bouchoueff, who obviously did not make any major contribution to the work of the institute? </span>
-                    <span id="d910e2895">
-                        <span id="dtb635">Haüy did not receive much help from his two assistants either, since they drank and turned out to be generally inept </span>
-                        <a id="dtb636" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_71">71</a>
-                        <span id="dtb637">. </span>
+                    <span id="dtb256">Haüy was also interested in the education of the deaf. </span>
+                    <span id="d910e1270">
+                        <span id="dtb257">He is said to have been actively involved in the teaching of deaf pupils and to have worked from time to time with the abbé l'épée </span>
+                        <a id="dtb258" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_16">16</a>
+                        <span id="dtb259">. </span>
                     </span>
-                    <span id="dtb638">Two other persons, however, announced their interest in teaching at Haüy's school. </span>
-                    <span id="dtb639">They were Galitch, a student at the Institute of Pedagogy in St Petersburg, and Louet, a French immigrant (a naturalized Russian citizen), who offered to give
-                        music classes.</span>
-                </p>
-                <div id="page_18" class="page-normal" epub:type="pagebreak" title="18"></div>
-                <p>
-                    <span id="dtb640">Galitch taught a pupil who came from the Kronstadt fortress in the Bay of Finland and who spoke only Russian. </span>
-                    <span id="dtb641">According to Skrébitsky, Bouchoueff had already lost heart in his work.</span>
-                </p>
-                <p>
-                    <span id="dtb642">Haüy had intended to reproduce the printing works he had had at the Institution des Jeunes Aveugles. </span>
-                    <span id="dtb643">A printing press was a major investment, but it had paid off well in Paris, and had, in fact, been the means of earning a regular income for the blind pupils and
-                        the institute. </span>
-                    <span id="dtb644">Haüy valued very highly the trades associated with printing. </span>
-                    <span id="dtb645">In the document dated 10th March 1807, he asked permission to establish a printing works at the institute, where not only ordinary books and books in raised print
-                        for the blind could be produced, but also such articles as visiting cards and other texts not subject to official censorship. </span>
-                    <span id="dtb646">Finally, he asked to be given the use of one of the crown's empty buildings for his institute, and to be allowed to select young blind people who could benefit
-                        from his teaching methods from the asylums, especially the Smolny asylum. </span>
-                    <span id="dtb647">He also wished to appoint staff to take charge of the administration of the institute.</span>
-                </p>
-                <p>
-                    <span id="dtb648">In his petition, Haüy also stressed that he had agreed to teach according to his methods for a period of one year, but that to date he had only been allowed to
-                        teach one pupil. </span>
-                    <span id="dtb649">By May 1807, Haüy still had no premises and once again sent a petition to the Minister of General Education in which he referred to former unfulfilled promises. </span>
-                    <span id="dtb650">He had been given a building, but it turned out to be unsuitable for a school. </span>
-                    <span id="dtb651">He further mentioned that attempts were still being made to convince him that there were no blind people in Russia, but that he had seen the many blind beggars
-                        for himself and had also seen many blind children in Smolny whom he would gladly teach.</span>
-                </p>
-                <p>
-                    <span id="dtb652">It has already been said that Haüy did have a few pupils, one of whom lived in his house. </span>
-                    <span id="dtb653">As there was no reaction from the minister, Haüy, who now only had four months of his contract left, decided to occupy the building offered in spite of the fact
-                        that it was not in a fit condition to house a school. </span>
-                    <span id="dtb654">Bouchoueff was still unwell and of little use to him. </span>
-                    <span id="dtb655">His two assistants, Galitch and Louet, however, did an excellent job.</span>
-                </p>
-                <p>
-                    <span id="dtb656">Once again Haüy asked to be allowed to select some blind children from the Smolny asylum as pupils. </span>
-                    <span id="dtb657">Skrébitsky states that he found no answer to this letter, although he did discover a decision by the tsar, dated 10th August 1807, giving Haüy permission to teach
-                        15 pupils at an annual cost of <span id="d910e2986" class="num-with-space">14 150</span> roubles with an extra allowance of <span id="d910e2989" class="num-with-space">5
-                            185</span> roubles, but this did not solve Haüy's problems. </span>
-                    <span id="dtb658">Now the authorities concerned began to harass him and demand that he should deduct the amount granted from what he had previously received. </span>
-                    <span id="dtb659">In addition, a heated debate ensued on the carriage required by Haüy to transport his purchases to the institute. </span>
-                    <span id="dtb660">The discussion ended when the tsar ordered General Hitrowo to tell Haüy to conduct himself in a proper manner.</span>
-                </p>
-                <p>
-                    <span id="dtb661">Prior to that curt, rather perfunctory decision, Baron Dolst, director of secondary schools, had been ordered to inspect Haüy's school. </span>
-                    <span id="dtb662">The inspection was preceded by a letter from Haüy to the minister of education, in which he wrote:</span>
-                </p>
-                <blockquote id="dtb663">
-                    <p>
-                        <span id="dtb664">"In answer to the objections expressed over the fact that I have undertaken to prepare my successor to take charge of the institute in six months or a year, I
-                            answer that this is quite correct but that the note referred to clearly states that there were two conditions: 1. </span>
-                        <span id="dtb665">That I would be given a sufficient number of blind pupils;2. </span>
-                        <span id="dtb666">That my colleague would be chosen in competition amongst those who in a special examination would be tested to see whether they possessed the talents required
-                            for this kind of education, which demands knowledge beyond what is expected in ordinary schools.</span>
-                    </p>
-                </blockquote>
-                <div id="page_19" class="page-normal" epub:type="pagebreak" title="19"></div>
-                <blockquote id="dtb667">
-                    <p>
-                        <span id="dtb668">I remain in your service as temporary head of the institute only because my colleague, who at an inopportune moment assured the ministry that he could manage
-                            the institute by himself, is far from fit to do so. </span>
-                        <span id="dtb669">I have, for several reasons, twenty times addressed M. </span>
-                        <span id="dtb670">De Novossilzeff at the chancellery, as my colleague has not dedicated sufficient time to his teaching. </span>
-                        <span id="dtb671">It would be beneficial if he would show his talents today rather than wait until tomorrow! </span>
-                        <span id="dtb672">I am in haste to leave a difficult profession, which I have exercised for 37 years and as my wishes now have been fulfilled and I can no longer be of any use,
-                            not even to Russia, I will enjoy the rest I am truly in need of.</span>
-                    </p>
-                    <p>
-                        <span id="dtb673">When I finally plead the justness of my demands, it is no criticism of the Tsar, the ministry or any of its respected officials. </span>
-                        <span id="dtb674">M. </span>
-                        <span id="dtb675">Bouchoueff alone is the reason why the Government, without realising it, has neglected its obligations to me."</span>
-                    </p>
-                </blockquote>
-                <p>
-                    <span id="d910e3066">
-                        <a id="dtb676" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_72">72</a>
-                        <span id="dtb677">.</span>
-                    </span>
-                </p>
-                <p>
-                    <span id="dtb678">This letter clearly shows that at this time relations between Haüy and Bouchoueff were extremely strained.</span>
-                </p>
-                <p>
-                    <span id="dtb679">Baron Dolst admitted in his report after his inspection of the institute (13th August 1808) that the premises to which it had moved were not suitable, located as
-                        they were on the fourth floor, with the dormitories next to the earth closets. </span>
-                    <span id="dtb680">As to the teaching at the institute, Dolst affirmed that he could find no differences in knowledge between the pupils taught by Haüy and those taught by
-                        Bouchoueff. </span>
-                    <span id="dtb681">He did find that a few pupils had made considerable progress in reading after following Haüy's methods, but that printing had had to be abandoned for lack of
-                        typecast. </span>
-                    <span id="dtb682">Basket-making and straw plaiting for chair bottoms were taught at the institute; the girls learned how to make hairnets and to knit. </span>
-                    <span id="dtb683">Dolst considered that the teaching of handicrafts had achieved good results.</span>
-                </p>
-                <p>
-                    <span id="dtb684">As for the teaching of music, however, Dolst was not satisfied. </span>
-                    <span id="dtb685">The children had learnt only three French and two Italian songs. </span>
-                    <span id="dtb686">The Baron did not find this lack of progress so remarkable, since the songs were all in foreign languages. </span>
-                    <span id="dtb687">He therefore suggested that the immigrant Louet should be replaced by a Russian music teacher who would be assisted by a blind person by the name of
-                        Shiline.</span>
-                </p>
-                <p>
-                    <span id="dtb688">After the inspection, Haüy asked Dolst if he might hand in his resignation and leave the institute together with Fournier and Louet. </span>
-                    <span id="dtb689">Dolst submitted Haüy's letter of resignation to the minister of education. </span>
-                    <span id="dtb690">In it he asked to be relieved of his duties because of the serious conflict between himself and Bouchoueff.</span>
-                </p>
-                <p>
-                    <span id="dtb691">According to Skrébitsky, neither Dolst's report nor Haüy's letter of resignation had any effect, and Haüy continued as head of the institute until 1817. </span>
-                    <span id="dtb692">Bouchoueff, too, retained his post at the institute and shortly afterwards disbanded the girls' section (which consisted of three pupils).</span>
-                </p>
-                <p>
-                    <span id="dtb693">Skrébitsky claims to have found notes by an anonymous writer in one of the archives. </span>
-                    <span id="dtb694">These notes proved that the original intention was to admit two categories of pupils to the institute: the poor, who would learn reading, writing, typesetting,
-                        music and handicrafts, and the well-to-do, who would learn writing, geography, poetry, etc. </span>
-                    <span id="dtb695">Religion would be a compulsory subject for both social groups.</span>
-                </p>
-                <p>
-                    <span id="dtb696">The author of the note was of the opinion that the Rosminazoffs' house, where the institute was located, was very suitable in spite of the fact that both Baron
-                        Dolst and Haüy thought the contrary. </span>
-                    <span id="dtb697">He was also very critical of Haüy, who he found had made improper use of his position by appropriating the best rooms for his own personal use.</span>
-                </p>
-                <div id="page_20" class="page-normal" epub:type="pagebreak" title="20"></div>
-                <p>
-                    <span id="dtb698">The children's dormitory was cold in winter and stiflingly hot in summer. </span>
-                    <span id="dtb699">To make matters worse, they were obliged to pass through the bedroom to empty their chamber pots. </span>
-                    <span id="dtb700">Music classes, study and a variety of activities were held in the general classroom while normal classes were going on. </span>
-                    <span id="dtb701">At one table, pupils were taught reading or grammar, at another arithmetic. </span>
-                    <span id="dtb702">The space for printing works was in one corner, while in the centre of the room, pupils played the piano or the violin. </span>
-                    <span id="dtb703">The anonymous author added that Haüy's son or his pupil Fournier sometimes amused themselves by adding to the general noise by starting up the lathe in order to
-                        disturb the Russian teachers at their work, and so that later they would be able to criticise their methods.</span>
-                </p>
-                <p>
-                    <span id="dtb704">The unknown critic also took a very negative view of the teaching of handicrafts. </span>
-                    <span id="dtb705">It had, for example, taken a whole year to teach a pupil to plait and the finished result was a mere half archine which would only fetch 10 kopeks. </span>
-                    <span id="dtb706">He also noted that the printing press was used only to print brochures about Haüy's telegraph, with the result that the type was worn and could not be used for
-                        its original purpose. </span>
-                    <span id="dtb707">The author accused Fournier, who was in charge of these activities, of deliberately destroying the type. </span>
-                    <span id="dtb708">The lathe was in equally bad shape, the music teaching deficient, etc. </span>
-                    <span id="dtb709">The author ends by suggesting that the French teachers should be dismissed and replaced by Russians.</span>
-                </p>
-                <p>
-                    <span id="dtb710">Haüy very much resented what he considered to be harassment which Skrébitsky believes Bouchoueff was responsible for. </span>
-                    <span id="dtb711">In a letter dated 19th August 1808, Haüy asked Count Zawadowsky (the minister of education) to order Baron Dolst to continue his inspections and demanded that
-                        examinations should be held in French in the presence of witnesses. </span>
-                    <span id="dtb712">Haüy wanted to be able to refute any criticism which might be made of his work and had no desire to be at the mercy of the caprice of a single judge. </span>
-                    <span id="dtb713">This letter was followed by another to Baron Dolst, in which Haüy asked to be allowed to participate in decisions concerning the final organisation of the
-                        institute. </span>
-                    <span id="dtb714">He yet again asked to be moved to more suitable premises and requested a list of poor blind children who might be admitted to the institute and another of
-                        well-to-do children who might be potential pupils.</span>
-                </p>
-                <p>
-                    <span id="dtb715">Bouchoueff died before Haüy left Russia. </span>
-                    <span id="dtb716">According to Skrébitsky, there are no sources which might explain why Haüy stayed in Russia for as long as eleven years, in spite of all adversities. </span>
-                    <span id="dtb717">An official document dated 6th May 1817 makes it clear that Haüy wished to leave the institute. </span>
-                    <span id="dtb718">It is a letter is addressed to Prince Galitzin (who had replaced Zawadowsky as minister of education). </span>
-                    <span id="dtb719">In it, Haüy asks to be removed from office or to be granted six months leave for himself and Fournier. </span>
-                    <span id="dtb720">As Haüy was in a state of ill health by this time, Galitzin agreed to his dismissal, stating that he would thus be able to end his days in the bosom of his
-                        family. </span>
-                    <span id="dtb721">The French ambassador requested permission to take Haüy and Fournier back to France aboard a warship which was soon to leave. </span>
-                    <span id="dtb722">The Tsar gave his approval to the application and on Haüy's departure decorated him with the Order of Saint Vladimir, fourth class.</span>
-                </p>
-            </section>
-            <section id="d910e3253">
-                <h3 id="d910e3255">3.9.4 Haüy's last will and testament</h3>
-                <p>
-                    <span id="dtb724">Before returning to France, Haüy wrote one more letter to the minister of education, Prince Galitzin, which Skrébitsky sees as Haüy's last will and
-                        testament:</span>
-                </p>
-                <blockquote id="dtb725">
-                    <p>
-                        <span id="dtb726">"It is urgent</span>
-                    </p>
-                    <p>
-                        <span id="dtb727">1) that you appoint in my place Mr. </span>
-                        <span id="dtb728">Protopopoff, an honest family man who has really made himself familiar with all aspects of our work.</span>
-                    </p>
-                    <p>
-                        <span id="dtb729">(2) The ministry must provide him with a worthy collaborator who can assist him by behaving appropriately and who possesses the necessary talents for the
-                            post. </span>
-                        <span id="dtb730">I have already nominated young Vaganoff as a worthy successor to this post.</span>
-                    </p>
-                    <div id="page_21" class="page-normal" epub:type="pagebreak" title="21"></div>
-                    <p>
-                        <span id="dtb731">(3) The minister, rather than the inspector, who does more harm than good, must appoint a person who will direct only the teaching of such handicrafts as may
-                            prepare the blind pupils for a trade. (4) For Fournier's post, the ministry should appoint the three blind pupils Smourof, Vemblad and Stiaguine and have them divide his
-                            honoraries into three equal parts. </span>
-                        <span id="dtb732">I take advantage of this occasion to ask the minister to persist in encouraging these three blind pupils and the three sighted members of the staff to manage
-                            the institute without external help. (5) The ministry must increase the number of pupils so that the institute Haüy founded can function successfully. </span>
-                        <span id="dtb733">The number of blind pupils has been restricted to 15, which is too few. </span>
-                        <span id="dtb734">This fact has constituted a major impediment to the institute's success, as we, for example, have had to allow our pupils to carry out a number of activities
-                            for which, to be successful, at least 60 pupils would have been necessary."</span>
-                    </p>
-                </blockquote>
-                <p>
-                    <span id="d910e3314">
-                        <a id="dtb735" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_73">73</a>
-                        <span id="dtb736">.</span>
+                    <span id="d910e1282">
+                        <span id="dtb260">We can assume that his interest in the handicapped had already been aroused in 1771 when he visited one of the public performances given by the abbé's deaf pupils </span>
+                        <a id="dtb261" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_17">17</a>
+                        <span id="dtb262">.</span>
                     </span>
                 </p>
             </section>
-            <section id="d910e3326">
-                <h3 id="d910e3328">3.9.5 The education of deaf pupils in St Petersburg</h3>
+            <section id="d910e1296">
+                <h2 id="d910e1298">3.3 The market in St Ovid's Square</h2>
                 <p>
-                    <span id="dtb738">At an early date, Haüy had become interested in the abbé l'épée's teaching of the deaf. </span>
-                    <span id="dtb739">Skrébitsky (1884) says that in 1784, the abbé l'épée on one occasion himself entrusted Haüy with the teaching of a deaf person. </span>
-                    <span id="dtb740">Skrébitsky's source was probably a footnote in Haüy's Essai sur l'Education des Aveugles. </span>
-                    <span id="dtb741">In one chapter, Haüy writes that he wished to compare the teaching of the blind with that of the deaf. </span>
-                    <span id="dtb742">This chapter, however, is mainly a panegyric dedicated to the abbé l'épée. </span>
-                    <span id="dtb743">In passing, however, Haüy says that he can testify to the fact that it is much easier to teach the blind than the deaf. </span>
-                    <span id="dtb744">In the footnote mentioned, Haüy states that he had had the opportunity of following the progress of a young deaf man who had been shipwrecked and washed ashore on
-                        the coast of Normandy. </span>
-                    <span id="dtb745">Haüy also promised that the partially deaf man would write his autobiography and that his blind pupils would print it. </span>
-                    <span id="dtb746">That promise, to the best of my knowledge, was never kept.</span>
-                </p>
-                <p>
-                    <span id="dtb747">In October 1807, a Russian lady approached Haüy and asked him to teach her deaf daughter. </span>
-                    <span id="dtb748">According to Skrébitsky's sources, Haüy commented on this as follows:</span>
-                </p>
-                <blockquote id="dtb749">
-                    <p>
-                        <span id="dtb750">"She imagined that I would agree to teach her daughter, Eugénie, who had been tormented by deafness since her early years. </span>
-                        <span id="dtb751">In vain I tried to dissuade her, on the pretext of my lack of practical experience of this difficult art, which often surpasses the capacity of even the very
-                            well-prepared. </span>
-                        <span id="dtb752">Eventually I had to give in and accept. </span>
-                        <span id="dtb753">The very limited progress I made with her soon attracted attention and further pupils were sent to me."</span>
-                    </p>
-                </blockquote>
-                <p>
-                    <span id="d910e3394">
-                        <a id="dtb754" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_74">74</a>
+                    <span id="d910e1306">
+                        <span id="dtb264">In a letter to his son, Haüy tells how during the annual market in St Ovid's Square in Paris, he saw blind musicians from the Quinze-Vingt asylum perform </span>
+                        <a id="dtb265" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_18">18</a>
+                        <span id="dtb266">. </span>
                     </span>
+                    <span id="dtb267">He was sitting at a café when he saw some very strange creatures fitted with huge paper spectacles and pointed hats with donkey's ears affixed to them. </span>
+                    <span id="dtb268">Sheet music was placed upside down on the blind musicians' music stands while they banged, blew, and squeezed noises out of their worn-out instruments.</span>
                 </p>
                 <p>
-                    <span id="dtb755">Haüy invited the public to observe his efforts in order to show the progress which could be made by means of methods of teaching the deaf which had developed in
-                        France. </span>
-                    <span id="dtb756">His work aroused great surprise and admiration, although there were also sceptics. </span>
-                    <span id="dtb757">Skrébitsky quotes Haüy, who recounts an incident which occurred during one of his public classes:</span>
+                    <span id="dtb269">Haüy was shocked by the way the disabled musicians' wretchedness was exaggerated by their ridiculous outfits. </span>
+                    <span id="dtb270">He was also upset by the callousness of the audience, who howled with laughter at this shambles of an orchestra. </span>
+                    <span id="dtb271">Haüy did not see any reason to laugh at people just because they had a physical impediment.</span>
                 </p>
-                <blockquote id="dtb758">
+                <div id="page_9" class="page-normal" epub:type="pagebreak" title="9"></div>
+                <p>
+                    <span id="dtb272">From that day he decided to dedicate his life to improving the conditions of the blind.</span>
+                </p>
+                <p>
+                    <span id="dtb273">In his letter, he reflects:</span>
+                </p>
+                <blockquote id="dtb274">
                     <p>
-                        <span id="dtb759">"One day, during one of my classes, when I had just finished praising the abbé l'épée and the abbé Sicard and was commenting on my admiration of the
-                            intelligence usually shown by my deaf-dumb pupils, a member of the audience pointed out that these children, whom Nature had treated so unkindly, only repeated, in
-                            parrot-fashion, what had been poured into their minds by their teachers. </span>
-                        <span id="dtb760">The person in question was suggesting that it was useless to teach this type of pupil. </span>
-                        <span id="dtb761">Considering all that has been achieved by the famous men who developed these teaching methods, this asseveration appeared to me a mockery of their talents and
-                            I was filled with a desire to defend them to the utmost, if they should indeed require my help.</span>
+                        <span id="dtb275">"We asked ourselves: does not a blind person recognise objects by their different shapes? </span>
+                        <span id="dtb276">Is he mistaken as to the value of a coin? </span>
+                        <span id="dtb277">Why should it be impossible for him to distinguish between a C and a G, or between an A and an F, if those letters were made easier to distinguish? </span>
+                        <span id="dtb278">We sometimes reflected on the use of this performance (...)</span>
                     </p>
-                </blockquote>
-                <div id="page_22" class="page-normal" epub:type="pagebreak" title="22"></div>
-                <blockquote id="dtb762">
                     <p>
-                        <span id="dtb763">M. l'abbé Sicard receives daily proof of the intelligence of the deaf-dumb when he gives them written exercises, when he makes them understand and when he
-                            sets them questions on subjects such as physics and morale..."</span>
+                        <span id="dtb279">We soon saw various examples that convinced us how useful it would be for the blind to have access to teaching methods which could increase their knowledge so
+                            that they would not have to wait for help or sometimes ask the sighted to help them, often to no avail"</span>
                     </p>
                 </blockquote>
                 <p>
-                    <span id="d910e3443">
-                        <a id="dtb764" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_75">75</a>
-                        <span id="dtb765">.</span>
+                    <span id="d910e1379">
+                        <a id="dtb280" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_19">19</a>
+                        <span id="dtb281">.</span>
                     </span>
-                </p>
-                <p>
-                    <span id="dtb766">Haüy did not become deeply involved in the teaching of the deaf, but did manage to arouse the interest of the Dowager Tsarina who had experts brought from France. </span>
-                    <span id="dtb767">Among them was a M. </span>
-                    <span id="dtb768">Jouffret, who became the most prominent figure in the teaching of the deaf during its pioneering years. </span>
-                    <span id="dtb769">However, writes Skrébitsky, after the initial period of interest, the teaching of the blind and the deaf was soon forgotten.</span>
                 </p>
             </section>
-        </section>
-        <section id="d910e3470">
-            <h2 id="d910e3472">3.10 Haüy's telegraph</h2>
-            <p>
-                <span id="dtb771">During his years of teaching, Haüy continued to take an interest in ciphers and codes. </span>
-                <span id="d910e3483">
-                    <span id="dtb772">He was, for example, very interested in the telegraph and its use in military intelligence </span>
-                    <a id="dtb773" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_76">76</a>
-                    <span id="dtb774"> (this was before electricity was in general use). </span>
-                </span>
-                <span id="dtb775">Haüy also probably saw the telegraph as a means of earning money. </span>
-                <span id="dtb776">The criticisms made against him by his opponents (section 3.9.3) are proof that telegraphic experimentation and the printing of brochures took place at the institute. </span>
-                <span id="dtb777">When Haüy first arrived in St Petersburg, he tried to interest the tsar in his telegraphic invention. </span>
-                <span id="d910e3505">
-                    <span id="dtb778">In a letter dated 1st July 1807, he described his invention and enclosed a brochure entitled Mémoire historique abrévé sur les télégraphes en général et sur les
-                        télégraphes de St Pétersbourg 1801 </span>
-                    <a id="dtb779" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_77">77</a>
-                    <span id="dtb780">. </span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb781">Haüy called his telegraph the "pasigraph". </span>
-                <span id="dtb782">It was based on a system of writing in which the symbols corresponded not to sounds but to concepts such as numbers or musical notes. </span>
-                <span id="dtb783">He explained that the system could be used during the day and at night by a simple addition to the machine. </span>
-                <span id="dtb784">The pasigraph was based on five elements of information: </span>
-            </p>
-            <blockquote id="dtb785">
+            <section id="d910e1390">
+                <h2 id="d910e1392">3.4 Maria Theresia von Paradis (1733-1808)</h2>
                 <p>
-                    <span id="dtb786">"1. </span>
-                    <span id="dtb787">A stenographic and sound alphabet;</span>
+                    <span id="dtb283">Maria Theresia von Paradis was a woman who had a significant influence on Haüy and his teaching methods. </span>
+                    <span id="dtb284">They met in Paris in 1785 while Paradis was on a concert tour of Europe. </span>
+                    <span id="dtb285">Weygand (1998) says that Haüy read an article in a Parisian newspaper informing the public that the blind child prodigy Mara Theresia von Paradis was in the city and
+                        decided to contact her. </span>
+                    <span id="d910e1409">
+                        <span id="dtb286">Maria Theresia von Paradis was born in Vienna and became blind at about 4 years of age </span>
+                        <a id="dtb287" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_20">20</a>
+                        <span id="dtb288">. </span>
+                    </span>
+                    <span id="dtb289">Jantsch suggests that the girl's blindness had hysterical origins. </span>
+                    <span id="dtb290">Her father was a well-to-do lawyer. </span>
+                    <span id="dtb291">Maria Theresia was extremely musical and became a virtuoso on the piano; she had her own school in Vienna where she taught piano and singing. </span>
+                    <span id="dtb292">Between 1784 and 1785, she toured Europe, playing at the courts of Paris, London, Brussels, Hanover and Berlin, and giving concerts in several other cities. </span>
+                    <span id="dtb293">Mozart composed a concerto for piano and orchestra especially for her European tour and von Paradis also wrote her own music, using a system for writing musical notes
+                        which she had had specially invented. </span>
                 </p>
                 <p>
-                    <span id="dtb788">2. </span>
-                    <span id="dtb789">A numerical element</span>
+                    <span id="dtb294">Before von Paradis set off on her grand tour of Europe, she had relief maps made of the different countries and cities she was to visit. </span>
+                    <span id="dtb295">On these maps, frontiers and rivers were embroidered in backstitch, while cities and towns were represented by different-sized buttons; large buttons for capitals,
+                        smaller buttons for smaller cities or towns. </span>
+                    <span id="d910e1446">
+                        <span id="dtb296">Von Paradis had raised texts printed; a special printing press was made for her by Wolfgang Ritter von Kempelen </span>
+                        <a id="dtb297" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_21">21</a>
+                        <span id="dtb298">. </span>
+                    </span>
                 </p>
                 <p>
-                    <span id="dtb790">3. </span>
-                    <span id="dtb791">A word element. </span>
+                    <span id="dtb299">Von Paradis corresponded with Johan Ludwig Weissenburg, who was also blind and who himself used raised maps and writing. </span>
+                    <span id="dtb300">Their letters show that they discussed how raised pictures and maps could be made. </span>
+                    <span id="dtb301">For mathematical calculations, Paradis used an arithmetic board made in England by Saunderson. </span>
                 </p>
                 <p>
-                    <span id="dtb792">4. </span>
-                    <span id="dtb793">A grammatical element and</span>
+                    <span id="d910e1473">
+                        <span id="dtb302">Haüy's meeting with Maria Theresia von Paradis gave him the inspiration and encouragement he so desperately needed at that time to develop an educational
+                            programme for blind children </span>
+                        <a id="dtb303" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_22">22</a>
+                        <span id="dtb304">. </span>
+                    </span>
+                    <span id="d910e1485">
+                        <span id="dtb305">He presented his plan, "Plan de l'Education à l'Usage des Aveugles," to the Philanthropic Society, which at that time sponsored twelve children from poor families </span>
+                        <a id="dtb306" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_23">23</a>
+                        <span id="dtb307">. </span>
+                    </span>
                 </p>
                 <p>
-                    <span id="dtb794">5. finally, a format.</span>
+                    <span id="d910e1501">
+                        <span id="dtb308">In his Essai sur l'Education des Enfans-Aveugles </span>
+                        <a id="dtb309" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_24">24</a>
+                        <span id="dtb310">, Haüy repeatedly mentions that several of the tools he recommended for the teaching of blind children had been used by Maria Theresia von Paradis. </span>
+                    </span>
+                </p>
+                <div id="page_10" class="page-normal" epub:type="pagebreak" title="10"></div>
+            </section>
+            <section id="d910e1519">
+                <h2 id="d910e1521">3.5 Haüy's meeting with Lesueur and the founding of l'Institution des Jeunes Aveugles</h2>
+                <p>
+                    <span id="d910e1529">
+                        <span id="dtb312">Haüy was convinced that the blind deserved a better life than begging and performing in market places </span>
+                        <a id="dtb313" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_25">25</a>
+                        <span id="dtb314">. </span>
+                    </span>
+                    <span id="dtb315">They ought to enjoy the same right to education and work as the sighted. </span>
+                    <span id="dtb316">Not until thirteen years after the market in St Ovid's Square did he have an opportunity to demonstrate that the blind could be educated. </span>
+                    <span id="dtb317">This occurred when he was invited to teach François Lesueur, or Le Sueur, as Didier-Weygand sometimes writes his name.</span>
                 </p>
                 <p>
-                    <span id="dtb795">These five elements of information, which together can be fitted onto a surface of about 4 archines in length and 1 archine in width, are sufficient to permit
-                        simple and rapid communication of all forms of speech, regardless of the language used. </span>
-                    <span id="dtb796">I ascribe to the secretaries and interpreters a knowledge of grammar and of the most important languages, for which the Russians show great skill. </span>
-                    <span id="dtb797">This prior knowledge permits them, in just a few days, to learn my system, my five elements of information and their use"</span>
+                    <span id="d910e1553">
+                        <span id="dtb318">Haüy first met Lesueur, standing begging at the entrance to the church of Saint-Germain-des Prés </span>
+                        <a id="dtb319" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_26">26</a>
+                        <span id="dtb320">. </span>
+                    </span>
+                    <span id="d910e1565">
+                        <span id="dtb321">Lesueur was a professional beggar who supported himself, his parents and four siblings with the money he was given by churchgoers (since the Middle Ages, the
+                            Catholic Church had allowed the blind to beg outside churches) </span>
+                        <a id="dtb322" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_27">27</a>
+                        <span id="dtb323">.</span>
+                    </span>
                 </p>
-            </blockquote>
-            <p>
-                <span id="d910e3593">
-                    <a id="dtb798" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_78">78</a>
-                    <span id="dtb799">. </span>
-                </span>
-            </p>
-            <p>
-                <span id="dtb800">To support his idea, Haüy contracted a mechanic by the name of Winzelmeyer to construct a small model of the pasigraph. </span>
-                <span id="dtb801">He demonstrated his invention to the head of the Russian Academy of Science, Novossiltzeff. </span>
-                <span id="dtb802">When the Minister of the Navy, Tchitchagoff, appointed a commission in 1808 to express its opinion on the British and French telegraphic systems, Haüy was present. </span>
-                <span id="dtb803">He was given the opportunity to test his pasigraph between the fortress of Kronstad and a frigate anchored seven verst off the coast of St Petersburg. </span>
-                <span id="d910e3618">
-                    <span id="dtb804">The experiment was successful as to speed and precision; however, it is not known what became of Haüy's telegraph </span>
-                    <a id="dtb805" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_79">79</a>
-                    <span id="dtb806">. </span>
-                </span>
-            </p>
-        </section>
-        <section id="d910e3633">
-            <h2 id="d910e3635">3.11 The final years</h2>
-            <p>
-                <span id="dtb808">After the defeat of Napoleon at Waterloo in 1814, the National Institute in Paris became once more an autonomous entity. </span>
-                <span id="d910e3646">
-                    <span id="dtb809">The new director was Sebastien Guillé, a doctor of medicine, a fanatical royalist and an orthodox Roman Catholic </span>
-                    <a id="dtb810" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_80">80</a>
-                    <span id="dtb811">. </span>
-                </span>
-                <span id="dtb812">He forbade Haüy to visit the school since he considered that he had betrayed the French monarchy during the Revolution. </span>
-                <span id="d910e3661">
-                    <span id="dtb813">He was particularly critical of Haüy's attitude to religion </span>
-                    <a id="dtb814" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_81">81</a>
-                    <span id="dtb815">. </span>
-                </span>
-            </p>
-            <div id="page_23" class="page-normal" epub:type="pagebreak" title="23"></div>
-            <p>
-                <span id="dtb816">Not until 1821 was Valentin Haüy able to revisit his old school, which had then been extended to admit some 60 pupils. </span>
-                <span id="dtb817">During a ceremony held on 21st August 1821, Haüy was honoured for his pioneering work in the education of the blind. </span>
-                <span id="dtb818">One of the participants in that ceremony was the young Louis Braille, who had joined the institute in 1819. </span>
-                <span id="dtb819">Valentin Haüy died on 18th March 1822, at his brother's home in Paris. </span>
-            </p>
+                <p>
+                    <span id="d910e1580">
+                        <span id="dtb324">The story goes on to tell how Haüy, when he gave Lesueur some money, was told, "You thought you gave me a measly sou when in fact it was an écu " </span>
+                        <a id="dtb325" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_28">28</a>
+                        <span id="dtb326">. </span>
+                    </span>
+                    <span id="dtb327">From this incident Haüy immediately drew conclusions regarding the fine sense of touch the blind possess. </span>
+                    <span id="dtb328">If we compare this version of their meeting with Haüy's own words in section 3.3, we can guess how the story originated.</span>
+                </p>
+                <p>
+                    <span id="dtb329">Haüy started by teaching Lesueur good manners, grammatically correct speech and arithmetic. </span>
+                    <span id="dtb330">Haüy's main interest, however, was teaching the blind to read. </span>
+                    <span id="dtb331">He had wooden letters made so that Lesueur could learn the alphabet and later learn to read. </span>
+                    <span id="dtb332">This was achieved by forming the letters into words in a wooden frame. </span>
+                    <span id="dtb333">In a similar way, Lesueur learned the four arithmetical rules; in this case, wooden numbers were placed in different compartments in a frame. </span>
+                    <span id="dtb334">A major problem proved to be a supply of books for Lesueur. </span>
+                    <span id="dtb335">Haüy soon realised that his pupil could recognise raised letters, so he began to produce raised letters on waxed paper. </span>
+                    <span id="dtb336">Haüy had started teaching Lesueur on 31st May 1784. </span>
+                    <span id="d910e1626">
+                        <span id="dtb337">By September of the same year, he was able to announce his progress in an article in the Journal de Paris </span>
+                        <a id="dtb338" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_29">29</a>
+                        <span id="dtb339">. </span>
+                    </span>
+                    <span id="dtb340">On November 18th, both teacher and pupil appeared before the Académie de l'écriture. </span>
+                    <span id="dtb341">It was common practice at that time for pupils to appear before the Academy and the Court, and not just "handicapped prodigies". </span>
+                    <span id="d910e1645">
+                        <span id="dtb342">The Academy apparently fulfilled some kind of educational inspecting and authorising function </span>
+                        <a id="dtb343" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_30">30</a>
+                        <span id="dtb344">.</span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb345">Lesueur could read, recognise countries on a map and identify raised numbers on cardboard. </span>
+                    <span id="dtb346">This made Haüy's name as a teacher of the blind. </span>
+                    <span id="d910e1667">
+                        <span id="dtb347">The Academy decided to recommend his methods of teaching the blind </span>
+                        <a id="dtb348" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_31">31</a>
+                        <span id="dtb349">. </span>
+                    </span>
+                    <span id="dtb350">Thanks to Haüy's brother René-Just, the French Academy of Science became interested in his teaching methods. </span>
+                    <span id="dtb351">Four members of the Academy studied Haüy's methods and expressed their approval. </span>
+                    <span id="d910e1686">
+                        <span id="dtb352">Their report was registered by the Academy on 16th February 1785 </span>
+                        <a id="dtb353" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_32">32</a>
+                        <span id="dtb354">.</span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb355">In January 1785, Haüy became a member of the Société Philanthropique which also entrusted him with the teaching of their twelve blind protégés. </span>
+                    <span id="d910e1704">
+                        <span id="dtb356">These were all young adults aged between 20 and 30 </span>
+                        <a id="dtb357" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_33">33</a>
+                        <span id="dtb358">. </span>
+                    </span>
+                    <span id="dtb359">Haüy could now rent a house in the Rue Coquillère where he taught his pupils. </span>
+                    <span id="dtb360">A year later, when the number of pupils had increased, he moved into a house in the Rue Notre-Dame-des-Victoires, where the Société Philanthropique had its workshop
+                        for the blind, and so l'Institution des Jeunes Aveugles (the Institute for Blind Children ) was born. </span>
+                    <span id="d910e1722">
+                        <span id="dtb361">The pupils who now arrived at the institute were young children </span>
+                        <a id="dtb362" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_34">34</a>
+                        <span id="dtb363">.</span>
+                    </span>
+                </p>
+                <div id="page_11" class="page-normal" epub:type="pagebreak" title="11"></div>
+                <p>
+                    <span id="dtb364">Twice a year the blind children performed before the Court. </span>
+                    <span id="dtb365">Louis XVI was patron of the institute and also contributed economically to its upkeep. </span>
+                    <span id="dtb366">In an appendix to Haüy's pamphlet, Essai sur l'éducation des Aveugles, there is a list of the first twelve pupils to perform at the Court.</span>
+                </p>
+                <p>
+                    <span id="dtb367">Boys and girls alike attended the institute. </span>
+                    <span id="dtb368">The blind children came from poor homes and were not charged for their tuition. </span>
+                    <span id="dtb369">Haüy did, however, accept sighted children from well-to-do families who paid for their children's education. </span>
+                    <span id="d910e1761">
+                        <span id="dtb370">Haüy believed that sighted and blind children should be educated together without restriction </span>
+                        <a id="dtb371" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_35">35</a>
+                        <span id="dtb372">.</span>
+                    </span>
+                </p>
+            </section>
+            <section id="d910e1775">
+                <h2 id="d910e1777">3.6 Valentin Haüy's teaching methods</h2>
+                <p>
+                    <span id="dtb374">Valentin Haüy's first and only pamphlet on his teaching methods was published in 1786 with the long title of Essai sur l'éducation des aveugles ou Exposé de différens
+                        moyens, vérifiés par l'expérience, pour les mettre en état de lire, à l'aide du tact, d'imprimer des livres dans lesquels ils puissent prendre des connaissances des langues,
+                        d'histoire, de la Géographie, de la Musique, &amp;c., d'exécuter différens travaux relatifs aux Métiers, &amp;c., Dédié au Roi, par M. </span>
+                    <span id="dtb375">Haüy. </span>
+                    <span id="dtb376">It was printed by Haüy's blind pupils. </span>
+                    <span id="dtb377">Only the preface was set in normal type; the main text was set in the type created by Haüy for use with ink print or raised print. </span>
+                    <span id="dtb378">It was dedicated to the French king, Louis XVI. </span>
+                    <span id="dtb379">The title page reads, "Au Roi", followed by a brief preface dedicated to the king:</span>
+                </p>
+                <blockquote id="dtb380">
+                    <p id="d910e1807" class="line">
+                        <span id="dtb381">"To the KING OF FRANCE</span>
+                    </p>
+                    <p id="d910e1813" class="line">
+                        <span id="dtb382">SIRE,</span>
+                    </p>
+                    <p>
+                        <span id="dtb383">THE Protection with which your Majesty honours distinguished Talents ascertains your Claim to their Reverence and Respect. </span>
+                        <span id="dtb384">But when their Productions have a Tendency to console the Miseries of suffering Humanity, they have still a more powerful Title to attract the attention of Louis
+                            the Beneficent. </span>
+                        <span id="dtb385">It was under the influence of Sentiments inspired by a Title so amiable, which is deeply engraven on all the Hearts of France, that I conceived the desire of
+                            presenting to your Majesty the Fruits of my Labours ; if they have any Value, they will owe it to the double Advantage of appearing under a Patronage so august, and of becoming
+                            Vehicles to the Bounty expected from Sovereign by the Young and unhappy, who have been early deprived of the Benefit of Light with all its numerous and important
+                            Resources.</span>
+                    </p>
+                    <p id="d910e1831" class="line">
+                        <span id="dtb386">I am, With the profoundest respect,</span>
+                    </p>
+                    <p id="d910e1837" class="line">
+                        <span id="dtb387">Sire,</span>
+                    </p>
+                    <p id="d910e1844" class="line">
+                        <span id="dtb388">Your Majesty’s most humble,</span>
+                    </p>
+                    <p id="d910e1850" class="line">
+                        <span id="dtb389">must obedient</span>
+                    </p>
+                    <p id="d910e1856" class="line">
+                        <span id="dtb390">and most faithful subject and Servant,</span>
+                    </p>
+                    <p id="d910e1862" class="line">
+                        <span id="dtb391">HAÙY".</span>
+                    </p>
+                </blockquote>
+                <p>
+                    <span id="dtb392">In his essay Haüy expounds his pedagogical theories and presents a programme of studies for blind children. </span>
+                    <span id="dtb393">His basic premise was that the "unfortunate Blind," who until then had been deprived of education, could in fact be educated and ought therefore to be given the
+                        opportunity to attend school and learn a trade by which they could later make a living.</span>
+                </p>
+                <p>
+                    <span id="dtb394">Each subject is dealt with in a short chapter. </span>
+                    <span id="dtb395">Haüy gives simple, practical advice on teaching methods and on the production of material for use in object lessons and of a variety of teaching aids.</span>
+                </p>
+                <div id="page_12" class="page-normal" epub:type="pagebreak" title="12"></div>
+                <p>
+                    <span id="dtb396">He lays particular stress on the methods to be used to teach blind children to read and write and on how to produce raised print books. </span>
+                    <span id="dtb397">An entire chapter is dedicated to explaining how blind pupils can be trained as compositors. </span>
+                    <span id="dtb398">He also attempts to demonstrate that those blind pupils who did learn some kind of handicraft (at Quinze-Vingt, for example) were able to earn their own living. </span>
+                    <span id="dtb399">Haüy therefore recommends that teaching of the blind should include activities such as the production of walking sticks and hairnets, sewing, bookbinding, etc.</span>
+                </p>
+                <p>
+                    <span id="dtb400">Haüy also insists that blind pupils should study history, geography and music. </span>
+                    <span id="dtb401">In the chapter on the teaching of geography, he mentions Maria Theresia von Paradis and stresses the importance of tactile maps and the terrestrial globe to
+                        illustrate the concepts of countries, lakes, rivers, mountains, etc. </span>
+                    <span id="d910e1914">
+                        <span id="dtb402">He goes on to describe the method of producing maps developed by von Paradis and Weissenburg </span>
+                        <a id="dtb403" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_36">36</a>
+                        <span id="dtb404">. </span>
+                    </span>
+                    <span id="d910e1926">
+                        <span id="dtb405">As for music and the possibility of a blind person's earning his living as a musician, Haüy points to von Paradis's success and her system of raised musical notes </span>
+                        <a id="dtb406" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_37">37</a>
+                        <span id="dtb407">.</span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb408">When he touches on the teaching of mathematics, Haüy affirms that although he admires Saunderson and Weissenburg's "arithmetic boards", he firmly believes that blind
+                        and sighted children should be taught together and for this reason he does not agree with the use of special mathematical teaching aids for blind children. </span>
+                    <span id="dtb409">Haüy does recognise that blind pupils may need some kind of assistance when drawing geometrical figures, for example, and had paper templates for this purpose.</span>
+                </p>
+                <p>
+                    <span id="d910e1950">
+                        <span id="dtb410">Haüy's invention, a method of producing raised letters on paper with the types he had cast, was completely new </span>
+                        <a id="dtb411" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_38">38</a>
+                        <span id="dtb412">. </span>
+                    </span>
+                    <span id="dtb413">He now saw as his principle task to attempt to produce as many copies of books for the blind as possible. </span>
+                    <span id="dtb414">He wanted every blind child to have his or her own collection of raised print books. </span>
+                    <span id="dtb415">In time he designed and had made a printing press which could produce raised print and to which he added a device for dyeing the raised letters black. </span>
+                    <span id="d910e1971">
+                        <span id="dtb416">The first two books printed by Haüy for his blind pupils were produced in this way </span>
+                        <a id="dtb417" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_39">39</a>
+                        <span id="dtb418">. </span>
+                    </span>
+                    <span id="dtb419">One was his own treatise on education for the blind: Essai sur l'Education des Enfans-Aveugles (1786); the other a historical review of the institute's first five
+                        years of existence entitled Notice Historique de l'Institution des Enfans-Aveugles (1791).</span>
+                </p>
+                <p>
+                    <span id="dtb420">Haüy believed that his printing method would make it possible for the blind to print books not only for their own use but also for the sighted. </span>
+                    <span id="dtb421">He dreamed of a time when his blind pupils would become teachers of sighted children; the blind teacher and the sighted pupils would read from the same book. </span>
+                    <span id="dtb422">Haüy's method was, however, a form of printing, that is, it involved typographic composition, so to enable the blind to correspond with the sighted in a simpler
+                        fashion, Haüy designed a "writing board" on which the writer wrote with a steel pen which had an undivided nib. </span>
+                    <span id="dtb423">His idea was that the blind person should write his letter by hand on the one side of a suitable type of paper. </span>
+                    <span id="dtb424">This would produce raised letters on the other side of the paper, letters which the writer himself would be able to read by touch. </span>
+                    <span id="d910e2006">
+                        <span id="dtb425">Unfortunately, his apparatus was not of much use to those who had never seen letters </span>
+                        <a id="dtb426" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_40">40</a>
+                        <span id="dtb427">.</span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb428">The school in the Rue Victoires did more than provide its blind pupils with a basic education, it also taught them a useful trade. </span>
+                    <span id="dtb429">Their teachers believed in the positive value of work. </span>
+                    <span id="dtb430">The children spun thread, wove, knitted, made leather belts and hairnets, etc. </span>
+                    <span id="dtb431">They produced raised print but also printed in ink. </span>
+                    <span id="d910e2034">
+                        <span id="dtb432">Towards the end of his essay on the education of the blind, </span>
+                        <a id="dtb433" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_41">41</a>
+                        <span id="dtb434"> there are ten or so examples of the blind children's printing activities (invitation cards, announcements, invoices, prospectuses, etc.). </span>
+                    </span>
+                    <span id="dtb435">Although Haüy had raised scores made, he did not at first consider music to be anything more than an entertainment for the blind.</span>
+                </p>
+                <div id="page_13" class="page-normal" epub:type="pagebreak" title="13"></div>
+                <p>
+                    <span id="d910e2056">
+                        <span id="dtb436">He changed his opinion later when he discovered that the blind could learn to play the organ and thus could be employed as church organists </span>
+                        <a id="dtb437" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_42">42</a>
+                        <span id="dtb438">.</span>
+                    </span>
+                </p>
+                <p>
+                    <span id="d910e2071">
+                        <span id="dtb439">The aim behind Haüy's teaching methods was to enable his blind pupils to communicate satisfactorily with the sighted </span>
+                        <a id="dtb440" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_43">43</a>
+                        <span id="dtb441">. </span>
+                    </span>
+                    <span id="dtb442">He therefore rejected all writing systems for the blind which did not use the Roman alphabet. </span>
+                    <span id="dtb443">He would probably never have approved of Braille's system.</span>
+                </p>
+                <p>
+                    <span id="d910e2092">
+                        <span id="dtb444">At first, boys and girls were taught together in mixed classes, but some years later, after Haüy had been severely criticised for the co-educational organisation
+                            of his school, the sexes were segregated </span>
+                        <a id="dtb445" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_44">44</a>
+                        <span id="dtb446">.</span>
+                    </span>
+                </p>
+                <p>
+                    <span id="d910e2107">
+                        <span id="dtb447">Haüy's successor at the institute, Guillé, was himself severely criticised for his harsh methods of punishment </span>
+                        <a id="dtb448" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_45">45</a>
+                        <span id="dtb449">. </span>
+                    </span>
+                    <span id="dtb450">In the accusations made against Guillé, his severity was compared with Haüy's mild methods and his concern for his pupils. </span>
+                    <span id="dtb451">It is not clear, however, whether the critics implied by this that Haüy never used corporal punishment.</span>
+                </p>
+            </section>
+            <section id="d910e2127">
+                <h2 id="d910e2129">3.7 The French Revolution</h2>
+                <p>
+                    <span id="dtb453">Louis XVI was Haüy's patron and the institute's most important financial sponsor. </span>
+                    <span id="dtb454">When the monarchy was overthrown in 1791, the Institute for the Blind came under the authority of the new revolutionary government. </span>
+                    <span id="dtb455">Education at the institute, however, continued along the same lines as it had done under the monarchy. </span>
+                    <span id="d910e2146">
+                        <span id="dtb456">The various revolutionary governments for their part believed that all forms of education should be free of charge and controlled by the State </span>
+                        <a id="dtb457" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_46">46</a>
+                        <span id="dtb458">. </span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb459">The National Convention issued a decree on 28th September 1791 which nationalised the Institute for the Blind. </span>
+                    <span id="dtb460">The need to reduce financial costs was responsible for the fusion of the Institute for the Blind and L'épée's Institute for the Deaf. </span>
+                    <span id="d910e2167">
+                        <span id="dtb461">The resulting institute was moved to a monastery </span>
+                        <a id="dtb462" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_47">47</a>
+                        <span id="dtb463">. </span>
+                    </span>
+                    <span id="dtb464">This fusion, however, was unsuccessful, and in 1794 the National Convention decided to separate the two schools once more. </span>
+                    <span id="dtb465">Haüy played an important part in this decision. </span>
+                    <span id="dtb466">He attacked l'épée's successor, Sicard, because he had criticised his teaching methods. </span>
+                    <span id="dtb467">Haüy was at that time a member of one of the revolutionary committees in Paris and was able to have Sicard arrested (Didier Weygand). </span>
+                    <span id="dtb468">Sicard was soon released, however, and two years later (1796) he had his revenge when he accused Haüy of belonging to an illegal secret society. </span>
+                    <span id="dtb469">Haüy was arrested and spent a brief spell in prison. </span>
+                </p>
+                <p>
+                    <span id="d910e2201">
+                        <span id="dtb470">After the break-up, the Institute for the Blind moved to a former convent at 34, Rue Denis, where it was renamed l'Institut National des Aveugles Travailleurs ,
+                            that is The National Institute for Blind Craftsmen </span>
+                        <a id="dtb471" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_48">48</a>
+                        <span id="dtb472">. </span>
+                    </span>
+                    <span id="dtb473">Coinciding with the move, the institute was reorganised and the pupils now had to contribute to the upkeep of the new, revolutionary France (28th July, 1795). </span>
+                    <span id="dtb474">The blind pupils' first task was to make 86 purses. </span>
+                    <span id="d910e2219">
+                        <span id="dtb475">At this point, the revolutionary committees began to debate whether institutes for the disabled should be classed as schools or asylums </span>
+                        <a id="dtb476" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_49">49</a>
+                        <span id="dtb477">. </span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb478">Haüy initially sided with the Revolution. </span>
+                    <span id="d910e2237">
+                        <span id="dtb479">He was, as we said, an active member of one of the revolutionary committees </span>
+                        <a id="dtb480" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_50">50</a>
+                        <span id="dtb481">, and on 8th of June 1794, "the Day of Pure Reason", he did not hesitate to have his blind musicians appear on a mobile platform from which he, in revolutionary
+                            language, urged them to follow Robespierre, who was dressed as the high priest of Pure Reason </span>
+                        <a id="dtb482" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_51">51</a>
+                        <span id="dtb483">. </span>
+                    </span>
+                </p>
+                <div id="page_14" class="page-normal" epub:type="pagebreak" title="14"></div>
+                <p>
+                    <span id="dtb484">Under the monarchy, his blind pupils regularly appeared in public to demonstrate their progress and these performances continued during the revolutionary period. </span>
+                    <span id="dtb485">Haüy's ability to adapt to the different régimes would later go against him, however. </span>
+                    <span id="d910e2268">
+                        <span id="dtb486">During the Directorate, Haüy founded what was called a theophilanthropic cult with two other revolutionaries, La Revellère-Lepeaux and Chemin-Dupontè </span>
+                        <a id="dtb487" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_52">52</a>
+                        <span id="dtb488">. </span>
+                    </span>
+                    <span id="dtb489">This could be described as a development of the cult of pure reason in which the magistrate assumed the role of the priest. </span>
+                    <span id="d910e2283">
+                        <span id="dtb490">The theophilanthropists substituted the head of the family for the priest; their philosophy was a mixture of theodicy and belief in the good individual </span>
+                        <a id="dtb491" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_53">53</a>
+                        <span id="dtb492">. </span>
+                    </span>
+                    <span id="dtb493">Haüy's successor as director of the institute (Guillé) was a strict Catholic who was horrified by Haüy's philosophical ideas. </span>
+                    <span id="dtb494">He later accused Haüy of heresy (amongst other things) as one of his reasons for not permitting Haüy to visit the institute. </span>
+                </p>
+                <p>
+                    <span id="dtb495">At the end of the revolutionary decade, the institute was bankrupt. </span>
+                    <span id="dtb496">The State owed the institute <span id="d910e2310" class="num-with-space">30 000</span> francs, apart from nine months' salary to teachers and other staff. </span>
+                    <span id="dtb497">Teachers and pupils alike starved and froze. </span>
+                    <span id="dtb498">Haüy lodged a complaint with the consular government but this was rejected outright; no money was forthcoming. </span>
+                    <span id="d910e2320">
+                        <span id="dtb499">His activities during the Reign of Terror and the Directorate spoke against him </span>
+                        <a id="dtb500" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_54">54</a>
+                        <span id="dtb501">. </span>
+                    </span>
+                    <span id="d910e2333">
+                        <span id="dtb502">On 14th March 1801, Napoleon Bonaparte, now First Consul, decided that the Institute for Blind Craftsmen should be integrated into the Quinze-Vingt Hospital, an
+                            asylum for elderly blind people which had existed since the end of the 13th Century </span>
+                        <a id="dtb503" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_55">55</a>
+                        <span id="dtb504">. </span>
+                    </span>
+                    <span id="dtb505">Napoleon furthermore forbade the theophilanthropists to practise their cult. </span>
+                    <span id="dtb506">Teaching at the institute was now reduced to two hours a day; during the rest of the day the blind children worked with sighted adults in the Quinze-Vingt workshops. </span>
+                    <span id="dtb507">Haüy was extremely affected and protested in three letters to the Minister of Interior Affairs (Lucien Bonaparte, one of Napoleon's brothers and Second Consul during
+                        the Second Consulate). </span>
+                    <span id="d910e2354">
+                        <span id="dtb508">The minister answered that the State was responsible for the education of the blind; Haüy's role was simply to carry out the State's orders </span>
+                        <a id="dtb509" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_56">56</a>
+                        <span id="dtb510">. </span>
+                    </span>
+                    <span id="dtb511">The answer to the last of the letters (dated 12th February 1802) was Haüy's dismissal, although he was granted a pension of 2000 livres a year. </span>
+                </p>
+            </section>
+            <section id="d910e2371">
+                <h2 id="d910e2373">3.8 Musée des Aveugles</h2>
+                <p>
+                    <span id="dtb513">In spite of this adversity, Haüy did not give up. </span>
+                    <span id="d910e2384">
+                        <span id="dtb514">He was now assured of an annual income of 2000 livres, so it was not long before he founded a private institute for the blind which he called the Musée des
+                            Aveugles </span>
+                        <a id="dtb515" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_57">57</a>
+                        <span id="dtb516">. </span>
+                    </span>
+                    <span id="dtb517">He planned that the new institute should complement the National Institute for the Blind. </span>
+                    <span id="dtb518">It was divided into two departments: one for pre-school children aged between four and seven years of age, the other for pupils over the age of sixteen who were
+                        taught a trade. </span>
+                    <span id="dtb519">Haüy was thus a precursor of Fröbel as far as pre-school education is concerned. </span>
+                    <span id="dtb520">The new institute fulfilled another of Haüy's dreams. </span>
+                    <span id="dtb521">His blind adolescent pupils taught the sighted children who boarded in an annexe of the Musée des Aveugles. </span>
+                    <span id="dtb522">In the long run, however, Haüy could not make ends meet and had to close the institute in 1806. </span>
+                    <span id="dtb523">According to Weygand (1998), he simply did not have enough pupils.</span>
+                </p>
+                <p>
+                    <span id="dtb524">Skrébitsky says that Haüy was very heavily in debt when he eventually arrived in St Petersburg. </span>
+                    <span id="d910e2424">
+                        <span id="dtb525">A Maltese banker, amongst others, demanded payment which was deducted from his salary in Russia </span>
+                        <a id="dtb526" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_58">58</a>
+                        <span id="dtb527">.</span>
+                    </span>
+                </p>
+                <div id="page_15" class="page-normal" epub:type="pagebreak" title="15"></div>
+            </section>
+            <section id="d910e2441">
+                <h2 id="d910e2443">3.9 Valentin Haüy in Russia</h2>
+                <section id="d910e2449">
+                    <h3 id="d910e2451">3.9.1 An invitation from Alexander I</h3>
+                    <p>
+                        <span id="dtb530">Word of Valentin Haüy's success soon spread throughout Europe. </span>
+                        <span id="d910e2462">
+                            <span id="dtb531">Several of the enlightened rulers were interested in acquiring his services </span>
+                            <a id="dtb532" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_59">59</a>
+                            <span id="dtb533">. </span>
+                        </span>
+                        <span id="dtb534">Teaching of the blind had started both in Vienna and in Berlin and Haüy exported his typographic cases and material for use in object lessons to institutes for
+                            the blind in these two capitals and in other European cities. </span>
+                        <span id="dtb535">When his finances were so depleted that he had to close down the Musée des Aveugles, a number of welcome invitations arrived, one of them from Tsar Alexander I of
+                            Russia. </span>
+                        <span id="d910e2480">
+                            <span id="dtb536">The tsar, himself educated in the spirit of Enlightenment </span>
+                            <a id="dtb537" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_60">60</a>
+                            <span id="dtb538">, invited Haüy to come to Russia for the purpose of founding an institute for the blind </span>
+                            <a id="dtb539" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_61">61</a>
+                            <span id="dtb540">.</span>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb541">According to Skrébitsky (1884), Alexander I employed a number of agents who informed him of every new idea that could successfully be introduced into Russia. </span>
+                        <span id="dtb542">Negotiations with Haüy were arranged by General Hitrowo, and plans were drawn up for the creation of an institute for the blind in St Petersburg. </span>
+                        <span id="dtb543">These plans show that Haüy had no intention of remaining in St Petersburg for any length of time. </span>
+                        <span id="dtb544">The project basically involved:</span>
+                    </p>
+                    <p>
+                        <span id="dtb545">1. </span>
+                        <span id="dtb546">The supervision, in Paris, of the production of all the teaching material destined for use in the education and occupation of blind children and adults in Russia. </span>
+                        <span id="dtb547">Haüy promised to take with him to Russia educational material such as letters and numbers for reading, counting and printing, maps, writing boards, etc.</span>
+                    </p>
+                    <p>
+                        <span id="dtb548">2. </span>
+                        <span id="dtb549">Haüy would travel to Russia the following Spring (1804) and remain there for about a year, accompanied by one of his blind pupils who had been taught by his
+                            methods. </span>
+                        <span id="dtb550">Haüy believed that his visit would bring success to the new institute and the ideas behind it and that it would encourage competition amongst the young
+                            Russians.</span>
+                    </p>
+                    <p>
+                        <span id="dtb551">3. </span>
+                        <span id="d910e2544">
+                            <span id="dtb552">Haüy, whose idea the project was, agreed to teach his methods faithfully to the person appointed by His Imperial Highness Alexander I to direct the St
+                                Petersburg Institute for the Blind </span>
+                            <a id="dtb553" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_62">62</a>
+                            <span id="dtb554">.</span>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb555">According to Skrébitsky, the Russian government asked Haüy's advice on the personal qualities and qualifications required of the new director of the St Petersburg
+                            institute for the blind, and on the economic compensation Haüy was willing to accept to take on the responsibility of setting up the institute. </span>
+                        <span id="dtb556">The Russian government also wanted to know how much the project would cost. </span>
+                        <span id="dtb557">As to the necessary qualities and qualifications of the director of the institute, Haüy (according to Skrébitsky) would have answered that this person should be
+                            selected from amongst those teachers who had a good knowledge of Russian and French and, if possible, German. </span>
+                        <span id="dtb558">The Director must also have an elementary knowledge of practical activities such as spinning, knitting, the making of hairnets, different kinds of weaving, etc. </span>
+                        <span id="dtb559">Haüy furthermore pointed out that the director must be familiar with the art of printing if he was to fulfil his task. </span>
+                        <span id="dtb560">Only an amateur's knowledge of music was required, however. </span>
+                        <span id="dtb561">Haüy added that apart from these basic qualifications, the director must have a good head on his shoulders, be gentle and patient and have a love for mankind in
+                            general.</span>
+                    </p>
+                    <p>
+                        <span id="dtb562">Haüy asked his imperial highness for an annual salary of at least <span id="d910e2586" class="num-with-space">40 000</span> roubles, of which half would be paid
+                            in advance when Haüy began his work. </span>
+                        <span id="dtb563">He also asked the crown to provide, at no cost to himself, a furnished house, light and fuel.</span>
+                    </p>
+                    <div id="page_16" class="page-normal" epub:type="pagebreak" title="16"></div>
+                    <p>
+                        <span id="dtb564">Finally, he asked for <span id="d910e2601" class="num-with-space">2 000</span> roubles in advance, as travel allowance for himself and his blind pupil. </span>
+                        <span id="dtb565">Haüy did not ask for travel allowances for his wife and son, who accompanied him to Russia. </span>
+                        <span id="dtb566">He estimated the costs of inventories, including teaching material such as maps and a globe, at <span id="d910e2610" class="num-with-space">4 500</span> francs
+                            and the annual operating costs, including salaries, at <span id="d910e2613" class="num-with-space">54 700</span> francs. </span>
+                        <span id="dtb567">The institute should be staffed by three teachers, one of them a music teacher, and a manager for the printing works.</span>
+                    </p>
+                    <p>
+                        <span id="dtb568">Haüy estimated that costs would decrease as the pupils progressed in their activities. </span>
+                        <span id="dtb569">This he based on his experience in Paris where his pupils, once they had acquired a certain degree of skill in handicrafts and printing were able to make a profit
+                            for the institute. </span>
+                        <span id="dtb570">Haüy was convinced that his experience in Paris could be transferred to St Petersburg, which shows how little he knew about the country he was about to
+                            visit.</span>
+                    </p>
+                </section>
+                <section id="d910e2634">
+                    <h3 id="d910e2636">3.9.2 Berlin</h3>
+                    <p>
+                        <span id="dtb572">Haüy made a stop in Berlin en route to Russia in 1806. </span>
+                        <span id="dtb573">He had already received a request from the king of Prussia who wondered if Haüy would be interested in founding a school for the blind in Berlin. </span>
+                        <span id="d910e2650">
+                            <span id="dtb574">In Prussia initiatives had already been taken in the 1780s to gain State control of all educational activities </span>
+                            <a id="dtb575" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_63">63</a>
+                            <span id="dtb576">. </span>
+                        </span>
+                        <span id="dtb577">King Frederick William III introduced Haüy to professor Johan August Zeune (1778-1853), who was already engaged in teaching blind children. </span>
+                        <span id="d910e2665">
+                            <span id="dtb578">Haüy and Zeune together designed a curriculum for an institute for the blind in Berlin </span>
+                            <a id="dtb579" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_64">64</a>
+                            <span id="dtb580">. </span>
+                        </span>
+                        <span id="dtb581">Professor Zeune later became the director of the institute. </span>
+                        <span id="d910e2681">
+                            <span id="dtb582">In Berlin as in Paris attempts were made to fulfil an important pedagogical objective: the combination of a theoretical-humanistic education and practical
+                                activities </span>
+                            <a id="dtb583" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_65">65</a>
+                            <span id="dtb584">. </span>
+                        </span>
+                        <span id="d910e2693">
+                            <span id="dtb585">The battle of Jena and Auerstedt delayed Haüy's departure for St Petersburg, but in spite of this delay, he took time during the journey from Berlin to make a
+                                detour to Mitau in Kurland (today Jelgava in Latvia), where the Bourbon pretender to the French throne, Louis XVIII, was living in exile </span>
+                            <a id="dtb586" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_66">66</a>
+                            <span id="dtb587">. </span>
+                        </span>
+                        <span id="dtb588">Haüy paid his respects to Louis XVIII, who assured him of his support when he returned to France.</span>
+                    </p>
+                </section>
+                <section id="d910e2710">
+                    <h3 id="d910e2712">3.9.3 In St Petersburg</h3>
+                    <p>
+                        <span id="dtb590">Haüy arrived in St Petersburg on September 9th 1806, and five days later sent a letter to the Tsar in which he sought an audience for himself and his
+                            seventeen-year-old blind pupil. </span>
+                        <span id="dtb591">He wrote that he thought the Tsar would be interested in meeting a blind person who was not only skilled in a handicraft but could also read and write and was
+                            well-versed in academic subjects such as history and geography. </span>
+                        <span id="d910e2726">
+                            <span id="dtb592">Haüy also wished to demonstrate an invention of his, the "advanced telegraph" </span>
+                            <a id="dtb593" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_67">67</a>
+                            <span id="dtb594">. </span>
+                        </span>
+                        <span id="dtb595">Skrébitsky states that he was unable to find any sources indicating that the Tsar actually received Haüy.</span>
+                    </p>
+                    <p>
+                        <span id="dtb596">Haüy's financial problems increased since none of the promises he had been given of compensation, a house, etc., were fulfilled. </span>
+                        <span id="dtb597">On 11th October 1806, he wrote a petition to the Tsar in which he set out his complaints. </span>
+                        <span id="d910e2750">
+                            <span id="dtb598">Skrébitsky says that he has found the letter in question and that it had a note in the margin (with a signature which probably belonged to the Minister of the
+                                General Education, Count Zawadowsky) which read, "The Tsar ordered this bill to be paid, premises to be found for the institute and a director who would learn Haüy's
+                                teaching methods to be selected and appointed to the institute" </span>
+                            <a id="dtb599" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_68">68</a>
+                            <span id="dtb600">. </span>
+                        </span>
+                        <span id="dtb601">Eight days after Haüy presented his petition, the money he had been promised was paid.</span>
+                    </p>
+                    <div id="page_17" class="page-normal" epub:type="pagebreak" title="17"></div>
+                    <p>
+                        <span id="dtb602">The person who became head of the new institute for the blind was a certain Bouchoueff, who taught at a school in St Petersburg and claimed he was sufficiently
+                            fluent in French to be able to converse with Haüy and learn his pedagogical ideas. </span>
+                        <span id="dtb603">Bouchoueff was to live in Haüy's house. </span>
+                        <span id="dtb604">A report from the ministry dated 10th March 1807 shows that Haüy employed two assistants to work with Bouchoueff and himself. </span>
+                        <span id="dtb605">Fournier, Haüy's blind pupil, helped to instruct these assistants. </span>
+                        <span id="dtb606">Haüy invited public officials and members of the Russian Academy of Science to be present during Fournier's lectures, hoping to enlist their support. </span>
+                        <span id="dtb607">However, there were still no blind pupils. </span>
+                        <span id="dtb608">Haüy was told that the lack of pupils arose from the fact that there were no blind people in Russia. </span>
+                        <span id="dtb609">To this, Haüy replied:</span>
+                    </p>
+                    <blockquote id="dtb610">
+                        <p>
+                            <span id="dtb611">"If no blind people are to be seen on the streets, this is because the head of the family keeps them at home and because orphans and the children of imperial
+                                serfs are placed in asylums. </span>
+                            <span id="dtb612">It was not long before events proved my assumption to be correct, not to mention the blind beggars who had escaped the surveillance of the police and to whom
+                                I hastened to give alms. </span>
+                            <span id="dtb613">I would gladly have quadrupled the alms had they consented to regard the money as a daily wage in exchange for their work."</span>
+                        </p>
+                    </blockquote>
+                    <p>
+                        <span id="d910e2815">
+                            <a id="dtb614" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_69">69</a>
+                            <span id="dtb615">.</span>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb616">At this time, St Petersburg was a town with a multicultural population. </span>
+                        <span id="dtb617">There were many families of French origin; French was, in fact, the language used by the educated classes; reviews and newspapers were published in French. </span>
+                        <span id="dtb618">In his quest for pupils, Haüy placed advertisements in Le Lycée, a review, and in the daily Gazette de Petersbourg. </span>
+                        <span id="dtb619">These advertisements brought him two new pupils, both of foreign extraction.</span>
+                    </p>
+                    <p>
+                        <span id="dtb620">After some time, a Russian woman came to Haüy asking him to help her blind son who was an inmate of the asylum in Smolny . </span>
+                        <span id="dtb621">Haüy went to Smolny where he found several blind children living with the aged and the handicapped inmates. </span>
+                        <span id="dtb622">He took the son of the woman who had asked for his help back to St Petersburg with him and asked the authorities for permission to teach the other blind children
+                            in Smolny. </span>
+                        <span id="dtb623">The children were to be picked up by coach, in twos, and later returned to the asylum. </span>
+                        <span id="dtb624">Haüy himself would undertake to teach the boys, while his wife would teach the little girls. </span>
+                        <span id="dtb625">The director of the Smolny asylum, however, refused to give his permission. </span>
+                        <span id="dtb626">Haüy then sent a written request to the "Committee for General Beneficence" and later to the "Civil Governor", who promised to grant Haüy's request as soon as he
+                            found time to do so. </span>
+                        <span id="dtb627">He never had, however, any spare time. </span>
+                        <span id="dtb628">In the same document (dated 10th March 1807), Haüy also complained about his cramped lodgings which made it impossible for him to take in more than one blind
+                            pupil at a time. </span>
+                        <span id="dtb629">His other pupil, from Moscow, had to lodge elsewhere in the town. </span>
+                        <span id="dtb630">Haüy asked the authorities to provide him with the house he had been promised to enable him to establish his school under more suitable conditions. </span>
+                        <span id="d910e2877">
+                            <span id="dtb631">In his letter Haüy also mentioned his two assistants and praised Bouchoueff, but complained about the latter's " weak health, which permitted him to dedicate
+                                only half-days to studies which required at least a year of continuous dedication" </span>
+                            <a id="dtb632" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_70">70</a>
+                            <span id="dtb633">.</span>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb634">Was it for tactical reasons that Haüy praised Bouchoueff, who obviously did not make any major contribution to the work of the institute? </span>
+                        <span id="d910e2895">
+                            <span id="dtb635">Haüy did not receive much help from his two assistants either, since they drank and turned out to be generally inept </span>
+                            <a id="dtb636" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_71">71</a>
+                            <span id="dtb637">. </span>
+                        </span>
+                        <span id="dtb638">Two other persons, however, announced their interest in teaching at Haüy's school. </span>
+                        <span id="dtb639">They were Galitch, a student at the Institute of Pedagogy in St Petersburg, and Louet, a French immigrant (a naturalized Russian citizen), who offered to give
+                            music classes.</span>
+                    </p>
+                    <div id="page_18" class="page-normal" epub:type="pagebreak" title="18"></div>
+                    <p>
+                        <span id="dtb640">Galitch taught a pupil who came from the Kronstadt fortress in the Bay of Finland and who spoke only Russian. </span>
+                        <span id="dtb641">According to Skrébitsky, Bouchoueff had already lost heart in his work.</span>
+                    </p>
+                    <p>
+                        <span id="dtb642">Haüy had intended to reproduce the printing works he had had at the Institution des Jeunes Aveugles. </span>
+                        <span id="dtb643">A printing press was a major investment, but it had paid off well in Paris, and had, in fact, been the means of earning a regular income for the blind pupils and
+                            the institute. </span>
+                        <span id="dtb644">Haüy valued very highly the trades associated with printing. </span>
+                        <span id="dtb645">In the document dated 10th March 1807, he asked permission to establish a printing works at the institute, where not only ordinary books and books in raised print
+                            for the blind could be produced, but also such articles as visiting cards and other texts not subject to official censorship. </span>
+                        <span id="dtb646">Finally, he asked to be given the use of one of the crown's empty buildings for his institute, and to be allowed to select young blind people who could benefit
+                            from his teaching methods from the asylums, especially the Smolny asylum. </span>
+                        <span id="dtb647">He also wished to appoint staff to take charge of the administration of the institute.</span>
+                    </p>
+                    <p>
+                        <span id="dtb648">In his petition, Haüy also stressed that he had agreed to teach according to his methods for a period of one year, but that to date he had only been allowed to
+                            teach one pupil. </span>
+                        <span id="dtb649">By May 1807, Haüy still had no premises and once again sent a petition to the Minister of General Education in which he referred to former unfulfilled promises. </span>
+                        <span id="dtb650">He had been given a building, but it turned out to be unsuitable for a school. </span>
+                        <span id="dtb651">He further mentioned that attempts were still being made to convince him that there were no blind people in Russia, but that he had seen the many blind beggars
+                            for himself and had also seen many blind children in Smolny whom he would gladly teach.</span>
+                    </p>
+                    <p>
+                        <span id="dtb652">It has already been said that Haüy did have a few pupils, one of whom lived in his house. </span>
+                        <span id="dtb653">As there was no reaction from the minister, Haüy, who now only had four months of his contract left, decided to occupy the building offered in spite of the fact
+                            that it was not in a fit condition to house a school. </span>
+                        <span id="dtb654">Bouchoueff was still unwell and of little use to him. </span>
+                        <span id="dtb655">His two assistants, Galitch and Louet, however, did an excellent job.</span>
+                    </p>
+                    <p>
+                        <span id="dtb656">Once again Haüy asked to be allowed to select some blind children from the Smolny asylum as pupils. </span>
+                        <span id="dtb657">Skrébitsky states that he found no answer to this letter, although he did discover a decision by the tsar, dated 10th August 1807, giving Haüy permission to teach
+                            15 pupils at an annual cost of <span id="d910e2986" class="num-with-space">14 150</span> roubles with an extra allowance of <span id="d910e2989" class="num-with-space">5
+                                185</span> roubles, but this did not solve Haüy's problems. </span>
+                        <span id="dtb658">Now the authorities concerned began to harass him and demand that he should deduct the amount granted from what he had previously received. </span>
+                        <span id="dtb659">In addition, a heated debate ensued on the carriage required by Haüy to transport his purchases to the institute. </span>
+                        <span id="dtb660">The discussion ended when the tsar ordered General Hitrowo to tell Haüy to conduct himself in a proper manner.</span>
+                    </p>
+                    <p>
+                        <span id="dtb661">Prior to that curt, rather perfunctory decision, Baron Dolst, director of secondary schools, had been ordered to inspect Haüy's school. </span>
+                        <span id="dtb662">The inspection was preceded by a letter from Haüy to the minister of education, in which he wrote:</span>
+                    </p>
+                    <blockquote id="dtb663">
+                        <p>
+                            <span id="dtb664">"In answer to the objections expressed over the fact that I have undertaken to prepare my successor to take charge of the institute in six months or a year, I
+                                answer that this is quite correct but that the note referred to clearly states that there were two conditions: 1. </span>
+                            <span id="dtb665">That I would be given a sufficient number of blind pupils;2. </span>
+                            <span id="dtb666">That my colleague would be chosen in competition amongst those who in a special examination would be tested to see whether they possessed the talents required
+                                for this kind of education, which demands knowledge beyond what is expected in ordinary schools.</span>
+                        </p>
+                    </blockquote>
+                    <div id="page_19" class="page-normal" epub:type="pagebreak" title="19"></div>
+                    <blockquote id="dtb667">
+                        <p>
+                            <span id="dtb668">I remain in your service as temporary head of the institute only because my colleague, who at an inopportune moment assured the ministry that he could manage
+                                the institute by himself, is far from fit to do so. </span>
+                            <span id="dtb669">I have, for several reasons, twenty times addressed M. </span>
+                            <span id="dtb670">De Novossilzeff at the chancellery, as my colleague has not dedicated sufficient time to his teaching. </span>
+                            <span id="dtb671">It would be beneficial if he would show his talents today rather than wait until tomorrow! </span>
+                            <span id="dtb672">I am in haste to leave a difficult profession, which I have exercised for 37 years and as my wishes now have been fulfilled and I can no longer be of any use,
+                                not even to Russia, I will enjoy the rest I am truly in need of.</span>
+                        </p>
+                        <p>
+                            <span id="dtb673">When I finally plead the justness of my demands, it is no criticism of the Tsar, the ministry or any of its respected officials. </span>
+                            <span id="dtb674">M. </span>
+                            <span id="dtb675">Bouchoueff alone is the reason why the Government, without realising it, has neglected its obligations to me."</span>
+                        </p>
+                    </blockquote>
+                    <p>
+                        <span id="d910e3066">
+                            <a id="dtb676" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_72">72</a>
+                            <span id="dtb677">.</span>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb678">This letter clearly shows that at this time relations between Haüy and Bouchoueff were extremely strained.</span>
+                    </p>
+                    <p>
+                        <span id="dtb679">Baron Dolst admitted in his report after his inspection of the institute (13th August 1808) that the premises to which it had moved were not suitable, located as
+                            they were on the fourth floor, with the dormitories next to the earth closets. </span>
+                        <span id="dtb680">As to the teaching at the institute, Dolst affirmed that he could find no differences in knowledge between the pupils taught by Haüy and those taught by
+                            Bouchoueff. </span>
+                        <span id="dtb681">He did find that a few pupils had made considerable progress in reading after following Haüy's methods, but that printing had had to be abandoned for lack of
+                            typecast. </span>
+                        <span id="dtb682">Basket-making and straw plaiting for chair bottoms were taught at the institute; the girls learned how to make hairnets and to knit. </span>
+                        <span id="dtb683">Dolst considered that the teaching of handicrafts had achieved good results.</span>
+                    </p>
+                    <p>
+                        <span id="dtb684">As for the teaching of music, however, Dolst was not satisfied. </span>
+                        <span id="dtb685">The children had learnt only three French and two Italian songs. </span>
+                        <span id="dtb686">The Baron did not find this lack of progress so remarkable, since the songs were all in foreign languages. </span>
+                        <span id="dtb687">He therefore suggested that the immigrant Louet should be replaced by a Russian music teacher who would be assisted by a blind person by the name of
+                            Shiline.</span>
+                    </p>
+                    <p>
+                        <span id="dtb688">After the inspection, Haüy asked Dolst if he might hand in his resignation and leave the institute together with Fournier and Louet. </span>
+                        <span id="dtb689">Dolst submitted Haüy's letter of resignation to the minister of education. </span>
+                        <span id="dtb690">In it he asked to be relieved of his duties because of the serious conflict between himself and Bouchoueff.</span>
+                    </p>
+                    <p>
+                        <span id="dtb691">According to Skrébitsky, neither Dolst's report nor Haüy's letter of resignation had any effect, and Haüy continued as head of the institute until 1817. </span>
+                        <span id="dtb692">Bouchoueff, too, retained his post at the institute and shortly afterwards disbanded the girls' section (which consisted of three pupils).</span>
+                    </p>
+                    <p>
+                        <span id="dtb693">Skrébitsky claims to have found notes by an anonymous writer in one of the archives. </span>
+                        <span id="dtb694">These notes proved that the original intention was to admit two categories of pupils to the institute: the poor, who would learn reading, writing, typesetting,
+                            music and handicrafts, and the well-to-do, who would learn writing, geography, poetry, etc. </span>
+                        <span id="dtb695">Religion would be a compulsory subject for both social groups.</span>
+                    </p>
+                    <p>
+                        <span id="dtb696">The author of the note was of the opinion that the Rosminazoffs' house, where the institute was located, was very suitable in spite of the fact that both Baron
+                            Dolst and Haüy thought the contrary. </span>
+                        <span id="dtb697">He was also very critical of Haüy, who he found had made improper use of his position by appropriating the best rooms for his own personal use.</span>
+                    </p>
+                    <div id="page_20" class="page-normal" epub:type="pagebreak" title="20"></div>
+                    <p>
+                        <span id="dtb698">The children's dormitory was cold in winter and stiflingly hot in summer. </span>
+                        <span id="dtb699">To make matters worse, they were obliged to pass through the bedroom to empty their chamber pots. </span>
+                        <span id="dtb700">Music classes, study and a variety of activities were held in the general classroom while normal classes were going on. </span>
+                        <span id="dtb701">At one table, pupils were taught reading or grammar, at another arithmetic. </span>
+                        <span id="dtb702">The space for printing works was in one corner, while in the centre of the room, pupils played the piano or the violin. </span>
+                        <span id="dtb703">The anonymous author added that Haüy's son or his pupil Fournier sometimes amused themselves by adding to the general noise by starting up the lathe in order to
+                            disturb the Russian teachers at their work, and so that later they would be able to criticise their methods.</span>
+                    </p>
+                    <p>
+                        <span id="dtb704">The unknown critic also took a very negative view of the teaching of handicrafts. </span>
+                        <span id="dtb705">It had, for example, taken a whole year to teach a pupil to plait and the finished result was a mere half archine which would only fetch 10 kopeks. </span>
+                        <span id="dtb706">He also noted that the printing press was used only to print brochures about Haüy's telegraph, with the result that the type was worn and could not be used for
+                            its original purpose. </span>
+                        <span id="dtb707">The author accused Fournier, who was in charge of these activities, of deliberately destroying the type. </span>
+                        <span id="dtb708">The lathe was in equally bad shape, the music teaching deficient, etc. </span>
+                        <span id="dtb709">The author ends by suggesting that the French teachers should be dismissed and replaced by Russians.</span>
+                    </p>
+                    <p>
+                        <span id="dtb710">Haüy very much resented what he considered to be harassment which Skrébitsky believes Bouchoueff was responsible for. </span>
+                        <span id="dtb711">In a letter dated 19th August 1808, Haüy asked Count Zawadowsky (the minister of education) to order Baron Dolst to continue his inspections and demanded that
+                            examinations should be held in French in the presence of witnesses. </span>
+                        <span id="dtb712">Haüy wanted to be able to refute any criticism which might be made of his work and had no desire to be at the mercy of the caprice of a single judge. </span>
+                        <span id="dtb713">This letter was followed by another to Baron Dolst, in which Haüy asked to be allowed to participate in decisions concerning the final organisation of the
+                            institute. </span>
+                        <span id="dtb714">He yet again asked to be moved to more suitable premises and requested a list of poor blind children who might be admitted to the institute and another of
+                            well-to-do children who might be potential pupils.</span>
+                    </p>
+                    <p>
+                        <span id="dtb715">Bouchoueff died before Haüy left Russia. </span>
+                        <span id="dtb716">According to Skrébitsky, there are no sources which might explain why Haüy stayed in Russia for as long as eleven years, in spite of all adversities. </span>
+                        <span id="dtb717">An official document dated 6th May 1817 makes it clear that Haüy wished to leave the institute. </span>
+                        <span id="dtb718">It is a letter is addressed to Prince Galitzin (who had replaced Zawadowsky as minister of education). </span>
+                        <span id="dtb719">In it, Haüy asks to be removed from office or to be granted six months leave for himself and Fournier. </span>
+                        <span id="dtb720">As Haüy was in a state of ill health by this time, Galitzin agreed to his dismissal, stating that he would thus be able to end his days in the bosom of his
+                            family. </span>
+                        <span id="dtb721">The French ambassador requested permission to take Haüy and Fournier back to France aboard a warship which was soon to leave. </span>
+                        <span id="dtb722">The Tsar gave his approval to the application and on Haüy's departure decorated him with the Order of Saint Vladimir, fourth class.</span>
+                    </p>
+                </section>
+                <section id="d910e3253">
+                    <h3 id="d910e3255">3.9.4 Haüy's last will and testament</h3>
+                    <p>
+                        <span id="dtb724">Before returning to France, Haüy wrote one more letter to the minister of education, Prince Galitzin, which Skrébitsky sees as Haüy's last will and
+                            testament:</span>
+                    </p>
+                    <blockquote id="dtb725">
+                        <p>
+                            <span id="dtb726">"It is urgent</span>
+                        </p>
+                        <p>
+                            <span id="dtb727">1) that you appoint in my place Mr. </span>
+                            <span id="dtb728">Protopopoff, an honest family man who has really made himself familiar with all aspects of our work.</span>
+                        </p>
+                        <p>
+                            <span id="dtb729">(2) The ministry must provide him with a worthy collaborator who can assist him by behaving appropriately and who possesses the necessary talents for the
+                                post. </span>
+                            <span id="dtb730">I have already nominated young Vaganoff as a worthy successor to this post.</span>
+                        </p>
+                        <div id="page_21" class="page-normal" epub:type="pagebreak" title="21"></div>
+                        <p>
+                            <span id="dtb731">(3) The minister, rather than the inspector, who does more harm than good, must appoint a person who will direct only the teaching of such handicrafts as may
+                                prepare the blind pupils for a trade. (4) For Fournier's post, the ministry should appoint the three blind pupils Smourof, Vemblad and Stiaguine and have them divide his
+                                honoraries into three equal parts. </span>
+                            <span id="dtb732">I take advantage of this occasion to ask the minister to persist in encouraging these three blind pupils and the three sighted members of the staff to manage
+                                the institute without external help. (5) The ministry must increase the number of pupils so that the institute Haüy founded can function successfully. </span>
+                            <span id="dtb733">The number of blind pupils has been restricted to 15, which is too few. </span>
+                            <span id="dtb734">This fact has constituted a major impediment to the institute's success, as we, for example, have had to allow our pupils to carry out a number of activities
+                                for which, to be successful, at least 60 pupils would have been necessary."</span>
+                        </p>
+                    </blockquote>
+                    <p>
+                        <span id="d910e3314">
+                            <a id="dtb735" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_73">73</a>
+                            <span id="dtb736">.</span>
+                        </span>
+                    </p>
+                </section>
+                <section id="d910e3326">
+                    <h3 id="d910e3328">3.9.5 The education of deaf pupils in St Petersburg</h3>
+                    <p>
+                        <span id="dtb738">At an early date, Haüy had become interested in the abbé l'épée's teaching of the deaf. </span>
+                        <span id="dtb739">Skrébitsky (1884) says that in 1784, the abbé l'épée on one occasion himself entrusted Haüy with the teaching of a deaf person. </span>
+                        <span id="dtb740">Skrébitsky's source was probably a footnote in Haüy's Essai sur l'Education des Aveugles. </span>
+                        <span id="dtb741">In one chapter, Haüy writes that he wished to compare the teaching of the blind with that of the deaf. </span>
+                        <span id="dtb742">This chapter, however, is mainly a panegyric dedicated to the abbé l'épée. </span>
+                        <span id="dtb743">In passing, however, Haüy says that he can testify to the fact that it is much easier to teach the blind than the deaf. </span>
+                        <span id="dtb744">In the footnote mentioned, Haüy states that he had had the opportunity of following the progress of a young deaf man who had been shipwrecked and washed ashore on
+                            the coast of Normandy. </span>
+                        <span id="dtb745">Haüy also promised that the partially deaf man would write his autobiography and that his blind pupils would print it. </span>
+                        <span id="dtb746">That promise, to the best of my knowledge, was never kept.</span>
+                    </p>
+                    <p>
+                        <span id="dtb747">In October 1807, a Russian lady approached Haüy and asked him to teach her deaf daughter. </span>
+                        <span id="dtb748">According to Skrébitsky's sources, Haüy commented on this as follows:</span>
+                    </p>
+                    <blockquote id="dtb749">
+                        <p>
+                            <span id="dtb750">"She imagined that I would agree to teach her daughter, Eugénie, who had been tormented by deafness since her early years. </span>
+                            <span id="dtb751">In vain I tried to dissuade her, on the pretext of my lack of practical experience of this difficult art, which often surpasses the capacity of even the very
+                                well-prepared. </span>
+                            <span id="dtb752">Eventually I had to give in and accept. </span>
+                            <span id="dtb753">The very limited progress I made with her soon attracted attention and further pupils were sent to me."</span>
+                        </p>
+                    </blockquote>
+                    <p>
+                        <span id="d910e3394">
+                            <a id="dtb754" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_74">74</a>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb755">Haüy invited the public to observe his efforts in order to show the progress which could be made by means of methods of teaching the deaf which had developed in
+                            France. </span>
+                        <span id="dtb756">His work aroused great surprise and admiration, although there were also sceptics. </span>
+                        <span id="dtb757">Skrébitsky quotes Haüy, who recounts an incident which occurred during one of his public classes:</span>
+                    </p>
+                    <blockquote id="dtb758">
+                        <p>
+                            <span id="dtb759">"One day, during one of my classes, when I had just finished praising the abbé l'épée and the abbé Sicard and was commenting on my admiration of the
+                                intelligence usually shown by my deaf-dumb pupils, a member of the audience pointed out that these children, whom Nature had treated so unkindly, only repeated, in
+                                parrot-fashion, what had been poured into their minds by their teachers. </span>
+                            <span id="dtb760">The person in question was suggesting that it was useless to teach this type of pupil. </span>
+                            <span id="dtb761">Considering all that has been achieved by the famous men who developed these teaching methods, this asseveration appeared to me a mockery of their talents and
+                                I was filled with a desire to defend them to the utmost, if they should indeed require my help.</span>
+                        </p>
+                    </blockquote>
+                    <div id="page_22" class="page-normal" epub:type="pagebreak" title="22"></div>
+                    <blockquote id="dtb762">
+                        <p>
+                            <span id="dtb763">M. l'abbé Sicard receives daily proof of the intelligence of the deaf-dumb when he gives them written exercises, when he makes them understand and when he
+                                sets them questions on subjects such as physics and morale..."</span>
+                        </p>
+                    </blockquote>
+                    <p>
+                        <span id="d910e3443">
+                            <a id="dtb764" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_75">75</a>
+                            <span id="dtb765">.</span>
+                        </span>
+                    </p>
+                    <p>
+                        <span id="dtb766">Haüy did not become deeply involved in the teaching of the deaf, but did manage to arouse the interest of the Dowager Tsarina who had experts brought from France. </span>
+                        <span id="dtb767">Among them was a M. </span>
+                        <span id="dtb768">Jouffret, who became the most prominent figure in the teaching of the deaf during its pioneering years. </span>
+                        <span id="dtb769">However, writes Skrébitsky, after the initial period of interest, the teaching of the blind and the deaf was soon forgotten.</span>
+                    </p>
+                </section>
+            </section>
+            <section id="d910e3470">
+                <h2 id="d910e3472">3.10 Haüy's telegraph</h2>
+                <p>
+                    <span id="dtb771">During his years of teaching, Haüy continued to take an interest in ciphers and codes. </span>
+                    <span id="d910e3483">
+                        <span id="dtb772">He was, for example, very interested in the telegraph and its use in military intelligence </span>
+                        <a id="dtb773" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_76">76</a>
+                        <span id="dtb774"> (this was before electricity was in general use). </span>
+                    </span>
+                    <span id="dtb775">Haüy also probably saw the telegraph as a means of earning money. </span>
+                    <span id="dtb776">The criticisms made against him by his opponents (section 3.9.3) are proof that telegraphic experimentation and the printing of brochures took place at the institute. </span>
+                    <span id="dtb777">When Haüy first arrived in St Petersburg, he tried to interest the tsar in his telegraphic invention. </span>
+                    <span id="d910e3505">
+                        <span id="dtb778">In a letter dated 1st July 1807, he described his invention and enclosed a brochure entitled Mémoire historique abrévé sur les télégraphes en général et sur les
+                            télégraphes de St Pétersbourg 1801 </span>
+                        <a id="dtb779" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_77">77</a>
+                        <span id="dtb780">. </span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb781">Haüy called his telegraph the "pasigraph". </span>
+                    <span id="dtb782">It was based on a system of writing in which the symbols corresponded not to sounds but to concepts such as numbers or musical notes. </span>
+                    <span id="dtb783">He explained that the system could be used during the day and at night by a simple addition to the machine. </span>
+                    <span id="dtb784">The pasigraph was based on five elements of information: </span>
+                </p>
+                <blockquote id="dtb785">
+                    <p>
+                        <span id="dtb786">"1. </span>
+                        <span id="dtb787">A stenographic and sound alphabet;</span>
+                    </p>
+                    <p>
+                        <span id="dtb788">2. </span>
+                        <span id="dtb789">A numerical element</span>
+                    </p>
+                    <p>
+                        <span id="dtb790">3. </span>
+                        <span id="dtb791">A word element. </span>
+                    </p>
+                    <p>
+                        <span id="dtb792">4. </span>
+                        <span id="dtb793">A grammatical element and</span>
+                    </p>
+                    <p>
+                        <span id="dtb794">5. finally, a format.</span>
+                    </p>
+                    <p>
+                        <span id="dtb795">These five elements of information, which together can be fitted onto a surface of about 4 archines in length and 1 archine in width, are sufficient to permit
+                            simple and rapid communication of all forms of speech, regardless of the language used. </span>
+                        <span id="dtb796">I ascribe to the secretaries and interpreters a knowledge of grammar and of the most important languages, for which the Russians show great skill. </span>
+                        <span id="dtb797">This prior knowledge permits them, in just a few days, to learn my system, my five elements of information and their use"</span>
+                    </p>
+                </blockquote>
+                <p>
+                    <span id="d910e3593">
+                        <a id="dtb798" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_78">78</a>
+                        <span id="dtb799">. </span>
+                    </span>
+                </p>
+                <p>
+                    <span id="dtb800">To support his idea, Haüy contracted a mechanic by the name of Winzelmeyer to construct a small model of the pasigraph. </span>
+                    <span id="dtb801">He demonstrated his invention to the head of the Russian Academy of Science, Novossiltzeff. </span>
+                    <span id="dtb802">When the Minister of the Navy, Tchitchagoff, appointed a commission in 1808 to express its opinion on the British and French telegraphic systems, Haüy was present. </span>
+                    <span id="dtb803">He was given the opportunity to test his pasigraph between the fortress of Kronstad and a frigate anchored seven verst off the coast of St Petersburg. </span>
+                    <span id="d910e3618">
+                        <span id="dtb804">The experiment was successful as to speed and precision; however, it is not known what became of Haüy's telegraph </span>
+                        <a id="dtb805" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_79">79</a>
+                        <span id="dtb806">. </span>
+                    </span>
+                </p>
+            </section>
+            <section id="d910e3633">
+                <h2 id="d910e3635">3.11 The final years</h2>
+                <p>
+                    <span id="dtb808">After the defeat of Napoleon at Waterloo in 1814, the National Institute in Paris became once more an autonomous entity. </span>
+                    <span id="d910e3646">
+                        <span id="dtb809">The new director was Sebastien Guillé, a doctor of medicine, a fanatical royalist and an orthodox Roman Catholic </span>
+                        <a id="dtb810" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_80">80</a>
+                        <span id="dtb811">. </span>
+                    </span>
+                    <span id="dtb812">He forbade Haüy to visit the school since he considered that he had betrayed the French monarchy during the Revolution. </span>
+                    <span id="d910e3661">
+                        <span id="dtb813">He was particularly critical of Haüy's attitude to religion </span>
+                        <a id="dtb814" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_81">81</a>
+                        <span id="dtb815">. </span>
+                    </span>
+                </p>
+                <div id="page_23" class="page-normal" epub:type="pagebreak" title="23"></div>
+                <p>
+                    <span id="dtb816">Not until 1821 was Valentin Haüy able to revisit his old school, which had then been extended to admit some 60 pupils. </span>
+                    <span id="dtb817">During a ceremony held on 21st August 1821, Haüy was honoured for his pioneering work in the education of the blind. </span>
+                    <span id="dtb818">One of the participants in that ceremony was the young Louis Braille, who had joined the institute in 1819. </span>
+                    <span id="dtb819">Valentin Haüy died on 18th March 1822, at his brother's home in Paris. </span>
+                </p>
+            </section>
         </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
@@ -107,243 +107,245 @@
         <link rel="prev" href="C00000-07-rearnotes.xhtml" />
         <link rel="next" href="C00000-09-part.xhtml" />
     </head>
-    <body id="d910e3694" epub:type="bodymatter chapter">
-        <h1 id="d910e3696">4. The importance of Haüy in the education of the blind in Sweden and elsewhere extra long title extra long title extra long title extra long title</h1>
-        <p>
-            <span id="d910e3707">
-                <span id="dtb822">Blind individuals have probably been educated to some degree or other in a number of countries throughout the world for many centuries </span>
-                <a id="dtb823" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_82">82</a>
-                <span id="dtb824">. </span>
-            </span>
-            <span id="dtb825">Organised education of the blind, however, did not exist before the end of the 18th century and the beginning of the 19th century.</span>
-        </p>
-        <p>
-            <span id="dtb826">D.G. </span>
-            <span id="dtb827">Pritchard (1965) demonstrated that organised education of the blind began in Britain in the 1780s, independent of Haüy, but that rumours of his work reached that country
-                after a few years. </span>
-            <span id="dtb828">Education of the blind in Britain, which was entirely private, initially only aimed at teaching the pupils some sort of handicraft while education proper can be said to
-                have commenced in 1800.</span>
-        </p>
-        <p>
-            <span id="dtb829">Education of the blind in the German-speaking world began, give or take a few years, at the period when Haüy initiated his activities. </span>
-            <span id="dtb830">In both cases John Locke and other Enlightenment philosophers exerted a powerful influence over the pioneers of education for the blind. </span>
-            <span id="d910e3743">
-                <span id="dtb831">Another pioneer in this field was Johan Wilhelm Klein, who in 1804 founded an institute for the blind in Vienna </span>
-                <a id="dtb832" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_83">83</a>
-                <span id="dtb833">. </span>
-            </span>
-            <span id="d910e3755">
-                <span id="dtb834">From the first, Klein regarded his school as a public concern </span>
-                <a id="dtb835" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_84">84</a>
-                <span id="dtb836"> and his real wish was to integrate blind children into ordinary classes. </span>
-            </span>
-            <span id="dtb837">Klein's institute was from the outset financed by the State, while the institute which Haüy and Zeune founded in Berlin in 1806 also received State funds.</span>
-        </p>
-        <p>
-            <span id="d910e3773">
-                <span id="dtb838">The birth of Swedish education for the blind is usually considered to have occurred in 1807 </span>
-                <a id="dtb839" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_85">85</a>
-                <span id="dtb840">. </span>
-            </span>
-            <span id="dtb841">At that time, the Keeper of Royal Records, Pär Aron Borg, received a visit from the 24- year old Charlotta Seijerling, who had become blind at the age of four and later
-                boarded with the Borg family where she was taught music, writing, arithmetic, German, French, etc. </span>
-            <span id="d910e3788">
-                <span id="dtb842">In Berättelse om den i Maj månad 1808 med en blind Elev hållne första Examen (The story of the first exam taken by a blind pupil in May 1808), Pär Aron Borg describes
-                    the public examination of Charlotta Seijerling, who was able to demonstrate her skill in reading, singing, playing the piano and the harp and also in "a number of handicrafts,
-                    which she had been taught such as spinning, knitting and needlework; and she had, particularly in the latter crafts, acquired such skill that she was able to show a sweater which
-                    she had made for herself". </span>
-                <a id="dtb843" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_86">86</a>
-                <span id="dtb844">. </span>
-            </span>
-            <span id="dtb845">This examination was held prior to the funding of the institute. </span>
-            <span id="dtb846">Borg points out that he had only been able to teach her in his "spare moments" and that Seijerling would probably have achieved much better results if she had been able
-                to dedicate more time to her education.</span>
-        </p>
-        <p>
-            <span id="dtb847">After this public examination, Borg asked the king, King Gustav IV Adolf, to contribute financially to extending the institute's activities so that greater numbers of
-                blind persons could be taught. </span>
-            <span id="dtb848">In his letter to the king, he also requested permission to teach the deaf. </span>
-            <span id="d910e3816">
-                <span id="dtb849">Borg's petition met with approval and he was granted an annual personal allowance of 450 riksdaler banco </span>
-                <a id="dtb850" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_87">87</a>
-                <span id="dtb851">. </span>
-            </span>
-            <span id="dtb852">Johansson is of the opinion that this decision led to the establishment in Sweden of an institute for the blind, the deaf and the mentally infirm.</span>
-        </p>
-        <div id="page_24" class="page-normal" epub:type="pagebreak" title="24"></div>
-        <p>
-            <span id="dtb853">The allowance continued to be paid after the events of March 1809, when Gustav IV Adolf was forced to abdicate in favour of his uncle (Carl XIII).</span>
-        </p>
-        <p>
-            <span id="d910e3843">
-                <span id="dtb854">In his application to the monarch for funds, Borg also committed himself to holding annual public examinations of the institute's pupils, as demanded by the new
-                    régime, which at the same time had increased the institute's funding </span>
-                <a id="dtb855" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_88">88</a>
-                <span id="dtb856">.</span>
-            </span>
-        </p>
-        <p>
-            <span id="dtb857">During the Autumn and Winter of 1808 to 1809, Borg initiated teaching activities on a larger scale, by accepting six deaf pupils and one blind pupil. </span>
-            <span id="d910e3861">
-                <span id="dtb858">Borg claimed that he was familiar with the educational methods in vogue in other countries in Europe, but that he preferred to follow his own ideas </span>
-                <a id="dtb859" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_89">89</a>
-                <span id="dtb860">. </span>
-            </span>
-            <span id="dtb861">With regard to the deaf, however, he allowed himself to be oriented by l'épée in his use of sign language and the finger alphabet. </span>
-            <span id="dtb862">Handicrafts formed an important part of his teaching methods, as they had for Haüy.</span>
-        </p>
-        <p>
-            <span id="dtb863">Johansson (1974) believes that it is difficult to form an idea of how the handicapped pupils were taught during the institute's early years on the basis of the material
-                which has survived. </span>
-            <span id="d910e3885">
-                <span id="dtb864">Because of the shortage of blind pupils, the institute eventually accepted only deaf children </span>
-                <a id="dtb865" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_90">90</a>
-                <span id="dtb866">. </span>
-            </span>
-            <span id="dtb867">Pär Aron Borg left the institute in 1818, after a series of conflicts, to found a private institute for the deaf in Manhem.</span>
-        </p>
-        <p>
-            <span id="dtb868">Serious debate on organised education for the blind and deaf did not develop until the introduction of the Elementary Schools Law in 1842. </span>
-            <span id="d910e3907">
-                <span id="dtb869">During the parliamentary session of 1844 to 1845, education for the disabled was discussed, and in the course of that debate it was in fact suggested that this type
-                    of education should be integrated into the general elementary school system </span>
-                <a id="dtb870" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_91">91</a>
-                <span id="dtb871">. </span>
-            </span>
-            <span id="dtb872">The decision to create a separate school for the blind was taken in the Riddarhus (House of the Nobility) by Nils af Zellén, head of department at the Ministry of
-                Education and Ecclesiastic Affairs. </span>
-            <span id="dtb873">In this debate, Zellén particularly emphasised the element of self-sufficiency and referred to the fact that most civilised countries in Europe had developed a system of
-                education which helped the blind to become self-supporting.</span>
-        </p>
-        <p>
-            <span id="d910e3928">
-                <span id="dtb874">Ossian Edmund Borg, the son of Pär Aron Borg, had become director of the General Institute for the Deaf at Manilla and was sent on a tour of Denmark, Germany, Belgium
-                    and France for the purpose of studying the progress of the education for the blind in these countries </span>
-                <a id="dtb875" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_92">92</a>
-                <span id="dtb876">. </span>
-            </span>
-            <span id="dtb877">In 1846, the Riksdag (Swedish parliament) decided that a new department for the blind should be established at Manilla. </span>
-            <span id="dtb878">This regulation of education for the deaf and blind was a symptom, in Förhammars opinion, of the socializing ideas which had inspired the Elementary School Law of 1842. </span>
-            <span id="dtb879">The blind were offered 13 free places (one from each diocese) at the Manilla institute. </span>
-            <span id="dtb880">The curriculum was to include reading, writing, Luther's catechism and handicrafts. </span>
-            <span id="dtb881">Musical skills would also be taught. </span>
-            <span id="d910e3956">
-                <span id="dtb882">The children would attend the institute from 12 to 18 years of age </span>
-                <a id="dtb883" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_93">93</a>
-                <span id="dtb884">. </span>
-            </span>
-            <span id="dtb885">Prior to that, they would be admitted to the school in the locality in which they officially resided.</span>
-        </p>
-        <p>
-            <span id="dtb886">In Denmark, the situation was somewhat different. </span>
-            <span id="d910e3977">
-                <span id="dtb887">The Kjaeden Order had been founded towards the end of the 18th century; one of its activities was helping the blind </span>
-                <a id="dtb888" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_94">94</a>
-                <span id="dtb889">. </span>
-            </span>
-            <span id="dtb890">Originally the Order ran an asylum which admitted a certain number of blind persons who were taught handicrafts. </span>
-            <span id="dtb891">This idea originated in France, where the Philanthropic Society carried out similar activities.</span>
-        </p>
-        <p>
-            <span id="dtb892">Word of the school for the blind in Paris reached Copenhagen, and in 1803, a young doctor by the name of P.A. </span>
-            <span id="dtb893">Castberg was commissioned by the Danish government (Cancelliet) to travel to Paris to study in the first place the education of the blind but also to "investigate the
-                organisation of the institutes for the blind which exist in Paris, where the blind, each according to his capacity, are educated to become useful citizens since they are taught
-                different skills in the production of a variety of articles."</span>
-        </p>
-        <div id="page_25" class="page-normal" epub:type="pagebreak" title="25"></div>
-        <p>
-            <span id="dtb894">Castberg spent the winter of 1804 to 1805 in Paris but there is no written testimony of his having informed the Institute for Blind Youth in Copenhagen of what he had
-                observed. </span>
-            <span id="dtb895">This is probably because the institute was not efficiently organised at that time. </span>
-            <span id="d910e4016">
-                <span id="dtb896">A letter from Castberg, however, contains an interesting piece of information; he mentions that during his stay in Paris he tried to buy Haüy's book but that only
-                    second-hand copies were to be had </span>
-                <a id="dtb897" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_95">95</a>
-                <span id="dtb898">. </span>
-            </span>
-            <span id="dtb899">He bought three copies, one of which he kept for himself. </span>
-            <span id="dtb900">One of the other copies eventually arrived in Dresden, where it was translated into German.</span>
-        </p>
-        <p>
-            <span id="d910e4038">
-                <span id="dtb901">A pamphlet entitled Journal udgiven til Fordel for Blinde was published in 1811 in Copenhagen in which an article on Haüy, written by Daniel Fürst, a merchant,
-                    appeared </span>
-                <a id="dtb902" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_96">96</a>
-                <span id="dtb903">. </span>
-            </span>
-            <span id="dtb904">Fürst writes that he spent six months in 1805 in daily contact with Haüy and that he had learned how to teach the blind from him. </span>
-            <span id="dtb905">It is not known whether Castberg and Fürst knew each other or whether they had met in Paris. </span>
-            <span id="dtb906">Castberg eventually became a leading figure in education for the deaf in Denmark and in 1818 was appointed head of the Manilla Institute in Stockholm.</span>
-        </p>
-        <p>
-            <span id="dtb907">Johansen states that in 1810 the Kjaeden Order was interested in expanding its activities and that one of its members, Brother C.F. </span>
-            <span id="dtb908">Brorson, suggested the creation of a school for blind children. </span>
-            <span id="dtb909">Frederick VI supported the project and personally contributed funds towards it. </span>
-            <span id="dtb910">He himself inaugurated the institute and named it "The Royal Institute for the Blind". </span>
-            <span id="dtb911">Johansen could find no evidence to indicate that Fürst was a member of the Kjaeden Order, although he did find proof that he had approached Brorson after the creation of
-                the institute for the blind and offered to teach there without compensation. </span>
-            <span id="dtb912">The institute's curriculum included reading and writing and Fürst is said to have taught those subjects. </span>
-            <span id="dtb913">Johansen, however, believes that education at the institute could not have been very successful, as Brorson was a decided opponent of the purchase of a printing press for
-                the production of raised print books. </span>
-            <span id="dtb914">The Danish Museum for the Blind, in spite of this opposition to the printing press, contains both a typographic case produced by Haüy and a copy of his famous essay. </span>
-            <span id="dtb915">Were they perhaps Fürst's? </span>
-            <span id="dtb916">Is the book one of the three copies Castberg bought in Paris? </span>
-            <span id="dtb917">These questions remain unanswered. </span>
-            <span id="dtb918">In the 1850s, management of the institute was taken over by the State. </span>
-            <span id="dtb919">Nationalisation was preceded by a commission headed by Professor N.G. </span>
-            <span id="dtb920">Melchior who had visited the institute in Paris in 1852 and seen for himself that blind pupils could learn to read with the help of raised print books. </span>
-            <span id="d910e4106">
-                <span id="dtb921">He later stated in his report that the Danish institute had not kept up with developments in this field </span>
-                <a id="dtb922" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_97">97</a>
-                <span id="dtb923">. </span>
-            </span>
-            <span id="dtb924">As a result of Melchior's report, the commission suggested that the institute should employ special teachers to teach the blind pupils to read and write. </span>
-            <span id="dtb925">They should learn not only to write in ink in order to be able to communicate with the sighted, but also the Braille system so that they could communicate with one
-                another. </span>
-            <span id="dtb926">It was further suggested in the report that in their own interest blind children should be taught in their local school during their early years. </span>
-            <span id="dtb927">They would then be admitted to the Institute for the Blind at the age of eleven.</span>
-        </p>
-        <p>
-            <span id="dtb928">Melchior later travelled to England to acquire suitable writing aids for the blind pupils.</span>
-        </p>
-        <figure class="image-series">
-            <!-- test for un-numbered pages -->
-            <div id="page_unnumbered_1" class="page-special" epub:type="pagebreak"></div>
-            <figure class="image">
-                <img alt="image" src="images/valentin.jpg" id="img_3" />
-                <div id="page_unnumbered_2" class="page-special" epub:type="pagebreak"></div>
+    <body>
+        <section id="d910e3694" epub:type="bodymatter chapter">
+            <h1 id="d910e3696">4. The importance of Haüy in the education of the blind in Sweden and elsewhere extra long title extra long title extra long title extra long title</h1>
+            <p>
+                <span id="d910e3707">
+                    <span id="dtb822">Blind individuals have probably been educated to some degree or other in a number of countries throughout the world for many centuries </span>
+                    <a id="dtb823" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_82">82</a>
+                    <span id="dtb824">. </span>
+                </span>
+                <span id="dtb825">Organised education of the blind, however, did not exist before the end of the 18th century and the beginning of the 19th century.</span>
+            </p>
+            <p>
+                <span id="dtb826">D.G. </span>
+                <span id="dtb827">Pritchard (1965) demonstrated that organised education of the blind began in Britain in the 1780s, independent of Haüy, but that rumours of his work reached that country
+                    after a few years. </span>
+                <span id="dtb828">Education of the blind in Britain, which was entirely private, initially only aimed at teaching the pupils some sort of handicraft while education proper can be said to
+                    have commenced in 1800.</span>
+            </p>
+            <p>
+                <span id="dtb829">Education of the blind in the German-speaking world began, give or take a few years, at the period when Haüy initiated his activities. </span>
+                <span id="dtb830">In both cases John Locke and other Enlightenment philosophers exerted a powerful influence over the pioneers of education for the blind. </span>
+                <span id="d910e3743">
+                    <span id="dtb831">Another pioneer in this field was Johan Wilhelm Klein, who in 1804 founded an institute for the blind in Vienna </span>
+                    <a id="dtb832" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_83">83</a>
+                    <span id="dtb833">. </span>
+                </span>
+                <span id="d910e3755">
+                    <span id="dtb834">From the first, Klein regarded his school as a public concern </span>
+                    <a id="dtb835" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_84">84</a>
+                    <span id="dtb836"> and his real wish was to integrate blind children into ordinary classes. </span>
+                </span>
+                <span id="dtb837">Klein's institute was from the outset financed by the State, while the institute which Haüy and Zeune founded in Berlin in 1806 also received State funds.</span>
+            </p>
+            <p>
+                <span id="d910e3773">
+                    <span id="dtb838">The birth of Swedish education for the blind is usually considered to have occurred in 1807 </span>
+                    <a id="dtb839" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_85">85</a>
+                    <span id="dtb840">. </span>
+                </span>
+                <span id="dtb841">At that time, the Keeper of Royal Records, Pär Aron Borg, received a visit from the 24- year old Charlotta Seijerling, who had become blind at the age of four and later
+                    boarded with the Borg family where she was taught music, writing, arithmetic, German, French, etc. </span>
+                <span id="d910e3788">
+                    <span id="dtb842">In Berättelse om den i Maj månad 1808 med en blind Elev hållne första Examen (The story of the first exam taken by a blind pupil in May 1808), Pär Aron Borg describes
+                        the public examination of Charlotta Seijerling, who was able to demonstrate her skill in reading, singing, playing the piano and the harp and also in "a number of handicrafts,
+                        which she had been taught such as spinning, knitting and needlework; and she had, particularly in the latter crafts, acquired such skill that she was able to show a sweater which
+                        she had made for herself". </span>
+                    <a id="dtb843" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_86">86</a>
+                    <span id="dtb844">. </span>
+                </span>
+                <span id="dtb845">This examination was held prior to the funding of the institute. </span>
+                <span id="dtb846">Borg points out that he had only been able to teach her in his "spare moments" and that Seijerling would probably have achieved much better results if she had been able
+                    to dedicate more time to her education.</span>
+            </p>
+            <p>
+                <span id="dtb847">After this public examination, Borg asked the king, King Gustav IV Adolf, to contribute financially to extending the institute's activities so that greater numbers of
+                    blind persons could be taught. </span>
+                <span id="dtb848">In his letter to the king, he also requested permission to teach the deaf. </span>
+                <span id="d910e3816">
+                    <span id="dtb849">Borg's petition met with approval and he was granted an annual personal allowance of 450 riksdaler banco </span>
+                    <a id="dtb850" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_87">87</a>
+                    <span id="dtb851">. </span>
+                </span>
+                <span id="dtb852">Johansson is of the opinion that this decision led to the establishment in Sweden of an institute for the blind, the deaf and the mentally infirm.</span>
+            </p>
+            <div id="page_24" class="page-normal" epub:type="pagebreak" title="24"></div>
+            <p>
+                <span id="dtb853">The allowance continued to be paid after the events of March 1809, when Gustav IV Adolf was forced to abdicate in favour of his uncle (Carl XIII).</span>
+            </p>
+            <p>
+                <span id="d910e3843">
+                    <span id="dtb854">In his application to the monarch for funds, Borg also committed himself to holding annual public examinations of the institute's pupils, as demanded by the new
+                        régime, which at the same time had increased the institute's funding </span>
+                    <a id="dtb855" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_88">88</a>
+                    <span id="dtb856">.</span>
+                </span>
+            </p>
+            <p>
+                <span id="dtb857">During the Autumn and Winter of 1808 to 1809, Borg initiated teaching activities on a larger scale, by accepting six deaf pupils and one blind pupil. </span>
+                <span id="d910e3861">
+                    <span id="dtb858">Borg claimed that he was familiar with the educational methods in vogue in other countries in Europe, but that he preferred to follow his own ideas </span>
+                    <a id="dtb859" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_89">89</a>
+                    <span id="dtb860">. </span>
+                </span>
+                <span id="dtb861">With regard to the deaf, however, he allowed himself to be oriented by l'épée in his use of sign language and the finger alphabet. </span>
+                <span id="dtb862">Handicrafts formed an important part of his teaching methods, as they had for Haüy.</span>
+            </p>
+            <p>
+                <span id="dtb863">Johansson (1974) believes that it is difficult to form an idea of how the handicapped pupils were taught during the institute's early years on the basis of the material
+                    which has survived. </span>
+                <span id="d910e3885">
+                    <span id="dtb864">Because of the shortage of blind pupils, the institute eventually accepted only deaf children </span>
+                    <a id="dtb865" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_90">90</a>
+                    <span id="dtb866">. </span>
+                </span>
+                <span id="dtb867">Pär Aron Borg left the institute in 1818, after a series of conflicts, to found a private institute for the deaf in Manhem.</span>
+            </p>
+            <p>
+                <span id="dtb868">Serious debate on organised education for the blind and deaf did not develop until the introduction of the Elementary Schools Law in 1842. </span>
+                <span id="d910e3907">
+                    <span id="dtb869">During the parliamentary session of 1844 to 1845, education for the disabled was discussed, and in the course of that debate it was in fact suggested that this type
+                        of education should be integrated into the general elementary school system </span>
+                    <a id="dtb870" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_91">91</a>
+                    <span id="dtb871">. </span>
+                </span>
+                <span id="dtb872">The decision to create a separate school for the blind was taken in the Riddarhus (House of the Nobility) by Nils af Zellén, head of department at the Ministry of
+                    Education and Ecclesiastic Affairs. </span>
+                <span id="dtb873">In this debate, Zellén particularly emphasised the element of self-sufficiency and referred to the fact that most civilised countries in Europe had developed a system of
+                    education which helped the blind to become self-supporting.</span>
+            </p>
+            <p>
+                <span id="d910e3928">
+                    <span id="dtb874">Ossian Edmund Borg, the son of Pär Aron Borg, had become director of the General Institute for the Deaf at Manilla and was sent on a tour of Denmark, Germany, Belgium
+                        and France for the purpose of studying the progress of the education for the blind in these countries </span>
+                    <a id="dtb875" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_92">92</a>
+                    <span id="dtb876">. </span>
+                </span>
+                <span id="dtb877">In 1846, the Riksdag (Swedish parliament) decided that a new department for the blind should be established at Manilla. </span>
+                <span id="dtb878">This regulation of education for the deaf and blind was a symptom, in Förhammars opinion, of the socializing ideas which had inspired the Elementary School Law of 1842. </span>
+                <span id="dtb879">The blind were offered 13 free places (one from each diocese) at the Manilla institute. </span>
+                <span id="dtb880">The curriculum was to include reading, writing, Luther's catechism and handicrafts. </span>
+                <span id="dtb881">Musical skills would also be taught. </span>
+                <span id="d910e3956">
+                    <span id="dtb882">The children would attend the institute from 12 to 18 years of age </span>
+                    <a id="dtb883" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_93">93</a>
+                    <span id="dtb884">. </span>
+                </span>
+                <span id="dtb885">Prior to that, they would be admitted to the school in the locality in which they officially resided.</span>
+            </p>
+            <p>
+                <span id="dtb886">In Denmark, the situation was somewhat different. </span>
+                <span id="d910e3977">
+                    <span id="dtb887">The Kjaeden Order had been founded towards the end of the 18th century; one of its activities was helping the blind </span>
+                    <a id="dtb888" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_94">94</a>
+                    <span id="dtb889">. </span>
+                </span>
+                <span id="dtb890">Originally the Order ran an asylum which admitted a certain number of blind persons who were taught handicrafts. </span>
+                <span id="dtb891">This idea originated in France, where the Philanthropic Society carried out similar activities.</span>
+            </p>
+            <p>
+                <span id="dtb892">Word of the school for the blind in Paris reached Copenhagen, and in 1803, a young doctor by the name of P.A. </span>
+                <span id="dtb893">Castberg was commissioned by the Danish government (Cancelliet) to travel to Paris to study in the first place the education of the blind but also to "investigate the
+                    organisation of the institutes for the blind which exist in Paris, where the blind, each according to his capacity, are educated to become useful citizens since they are taught
+                    different skills in the production of a variety of articles."</span>
+            </p>
+            <div id="page_25" class="page-normal" epub:type="pagebreak" title="25"></div>
+            <p>
+                <span id="dtb894">Castberg spent the winter of 1804 to 1805 in Paris but there is no written testimony of his having informed the Institute for Blind Youth in Copenhagen of what he had
+                    observed. </span>
+                <span id="dtb895">This is probably because the institute was not efficiently organised at that time. </span>
+                <span id="d910e4016">
+                    <span id="dtb896">A letter from Castberg, however, contains an interesting piece of information; he mentions that during his stay in Paris he tried to buy Haüy's book but that only
+                        second-hand copies were to be had </span>
+                    <a id="dtb897" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_95">95</a>
+                    <span id="dtb898">. </span>
+                </span>
+                <span id="dtb899">He bought three copies, one of which he kept for himself. </span>
+                <span id="dtb900">One of the other copies eventually arrived in Dresden, where it was translated into German.</span>
+            </p>
+            <p>
+                <span id="d910e4038">
+                    <span id="dtb901">A pamphlet entitled Journal udgiven til Fordel for Blinde was published in 1811 in Copenhagen in which an article on Haüy, written by Daniel Fürst, a merchant,
+                        appeared </span>
+                    <a id="dtb902" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_96">96</a>
+                    <span id="dtb903">. </span>
+                </span>
+                <span id="dtb904">Fürst writes that he spent six months in 1805 in daily contact with Haüy and that he had learned how to teach the blind from him. </span>
+                <span id="dtb905">It is not known whether Castberg and Fürst knew each other or whether they had met in Paris. </span>
+                <span id="dtb906">Castberg eventually became a leading figure in education for the deaf in Denmark and in 1818 was appointed head of the Manilla Institute in Stockholm.</span>
+            </p>
+            <p>
+                <span id="dtb907">Johansen states that in 1810 the Kjaeden Order was interested in expanding its activities and that one of its members, Brother C.F. </span>
+                <span id="dtb908">Brorson, suggested the creation of a school for blind children. </span>
+                <span id="dtb909">Frederick VI supported the project and personally contributed funds towards it. </span>
+                <span id="dtb910">He himself inaugurated the institute and named it "The Royal Institute for the Blind". </span>
+                <span id="dtb911">Johansen could find no evidence to indicate that Fürst was a member of the Kjaeden Order, although he did find proof that he had approached Brorson after the creation of
+                    the institute for the blind and offered to teach there without compensation. </span>
+                <span id="dtb912">The institute's curriculum included reading and writing and Fürst is said to have taught those subjects. </span>
+                <span id="dtb913">Johansen, however, believes that education at the institute could not have been very successful, as Brorson was a decided opponent of the purchase of a printing press for
+                    the production of raised print books. </span>
+                <span id="dtb914">The Danish Museum for the Blind, in spite of this opposition to the printing press, contains both a typographic case produced by Haüy and a copy of his famous essay. </span>
+                <span id="dtb915">Were they perhaps Fürst's? </span>
+                <span id="dtb916">Is the book one of the three copies Castberg bought in Paris? </span>
+                <span id="dtb917">These questions remain unanswered. </span>
+                <span id="dtb918">In the 1850s, management of the institute was taken over by the State. </span>
+                <span id="dtb919">Nationalisation was preceded by a commission headed by Professor N.G. </span>
+                <span id="dtb920">Melchior who had visited the institute in Paris in 1852 and seen for himself that blind pupils could learn to read with the help of raised print books. </span>
+                <span id="d910e4106">
+                    <span id="dtb921">He later stated in his report that the Danish institute had not kept up with developments in this field </span>
+                    <a id="dtb922" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_97">97</a>
+                    <span id="dtb923">. </span>
+                </span>
+                <span id="dtb924">As a result of Melchior's report, the commission suggested that the institute should employ special teachers to teach the blind pupils to read and write. </span>
+                <span id="dtb925">They should learn not only to write in ink in order to be able to communicate with the sighted, but also the Braille system so that they could communicate with one
+                    another. </span>
+                <span id="dtb926">It was further suggested in the report that in their own interest blind children should be taught in their local school during their early years. </span>
+                <span id="dtb927">They would then be admitted to the Institute for the Blind at the age of eleven.</span>
+            </p>
+            <p>
+                <span id="dtb928">Melchior later travelled to England to acquire suitable writing aids for the blind pupils.</span>
+            </p>
+            <figure class="image-series">
+                <!-- test for un-numbered pages -->
+                <div id="page_unnumbered_1" class="page-special" epub:type="pagebreak"></div>
+                <figure class="image">
+                    <img alt="image" src="images/valentin.jpg" id="img_3" />
+                    <div id="page_unnumbered_2" class="page-special" epub:type="pagebreak"></div>
+                </figure>
+                <figure class="image">
+                    <img alt="image" src="images/valentin.jpg" id="img_4" />
+                    <div id="page_unnumbered_3" class="page-special" epub:type="pagebreak"></div>
+                </figure>
+                <figure class="image">
+                    <img alt="image" src="images/valentin.jpg" id="img_5" />
+                </figure>
             </figure>
-            <figure class="image">
-                <img alt="image" src="images/valentin.jpg" id="img_4" />
-                <div id="page_unnumbered_3" class="page-special" epub:type="pagebreak"></div>
-            </figure>
-            <figure class="image">
-                <img alt="image" src="images/valentin.jpg" id="img_5" />
-            </figure>
-        </figure>
-        <div id="page_26" class="page-normal" epub:type="pagebreak" title="26"></div>
-        <p>
-            <span id="dtb929">In 1855, Haüy's Essai sur l'Education des Aveugles was translated into Danish by a young blind man by the name of Hans S/ondring. </span>
-            <span id="dtb930">The Danish translation was called Om de Blinde (About the Blind). </span>
-            <span id="dtb931">The National Institute for the Blind was inaugurated in 1856; the Kjaeden Order's final contribution to the education of blind children was to assume the costs of the new
-                school building. </span>
-            <span id="dtb932">The Order is still in existence and funds research into the history of the blind. </span>
-            <span id="dtb933">From all this, it is obvious that Haüy's methods did not reach Denmark until the middle of the 19th century, in spite of Fürst's activities.</span>
-        </p>
-        <div>
-            <p><span class="asciimath">`alpha`</span></p>
-            <p><span class="asciimath">`10 " cm"^2`</span></p>
-            <p><span class="asciimath">`0.5 * 100 * 1500 - 65000 = 10000`</span></p>
-            <p><span class="asciimath">`"Lutningen" = "höjden av ett trappsteg"/"bredden av ett trappsteg" = 3/5 = 0.6`</span></p>
-            <p><span class="asciimath">`p^2 &gt; 5q`</span></p>
-            <p><span class="asciimath">`p^2 &lt; 5q`</span></p>
-            <p><span class="asciimath">`3x - 2 &gt;= 20`</span></p>
-            <p><span class="asciimath">`0 &lt; x &lt;= 10`</span></p>
-            <p><span class="asciimath">`(4x^3)/(3x)`</span></p>
-            <p><span class="asciimath">`(5a)/5=125/5`</span></p>
-            <p><span class="asciimath">`(n - 2)^2 = "---" - 5n + "---"`</span></p>
-            <p><span class="asciimath">`sqrt 43`</span></p>
-            <p><span class="asciimath">`sqrt (43 * 4)`</span></p>
-        </div>
+            <div id="page_26" class="page-normal" epub:type="pagebreak" title="26"></div>
+            <p>
+                <span id="dtb929">In 1855, Haüy's Essai sur l'Education des Aveugles was translated into Danish by a young blind man by the name of Hans S/ondring. </span>
+                <span id="dtb930">The Danish translation was called Om de Blinde (About the Blind). </span>
+                <span id="dtb931">The National Institute for the Blind was inaugurated in 1856; the Kjaeden Order's final contribution to the education of blind children was to assume the costs of the new
+                    school building. </span>
+                <span id="dtb932">The Order is still in existence and funds research into the history of the blind. </span>
+                <span id="dtb933">From all this, it is obvious that Haüy's methods did not reach Denmark until the middle of the 19th century, in spite of Fürst's activities.</span>
+            </p>
+            <div>
+                <p><span class="asciimath">`alpha`</span></p>
+                <p><span class="asciimath">`10 " cm"^2`</span></p>
+                <p><span class="asciimath">`0.5 * 100 * 1500 - 65000 = 10000`</span></p>
+                <p><span class="asciimath">`"Lutningen" = "höjden av ett trappsteg"/"bredden av ett trappsteg" = 3/5 = 0.6`</span></p>
+                <p><span class="asciimath">`p^2 &gt; 5q`</span></p>
+                <p><span class="asciimath">`p^2 &lt; 5q`</span></p>
+                <p><span class="asciimath">`3x - 2 &gt;= 20`</span></p>
+                <p><span class="asciimath">`0 &lt; x &lt;= 10`</span></p>
+                <p><span class="asciimath">`(4x^3)/(3x)`</span></p>
+                <p><span class="asciimath">`(5a)/5=125/5`</span></p>
+                <p><span class="asciimath">`(n - 2)^2 = "---" - 5n + "---"`</span></p>
+                <p><span class="asciimath">`sqrt 43`</span></p>
+                <p><span class="asciimath">`sqrt (43 * 4)`</span></p>
+            </div>
+        </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-09-part.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-09-part.xhtml
@@ -107,30 +107,32 @@
         <link rel="prev" href="C00000-08-chapter.xhtml"/>
         <link rel="next" href="C00000-10-chapter.xhtml"/>
     </head>
-    <body epub:type="bodymatter part" id="poem-part">
-        <h1>Poem test</h1>
-        <section epub:type="z3998:poem" class="poem" id="poem1">
-            <h2>Poem headline</h2>
-            <div class="linegroup">
-                <p class="line">...verse line...</p>
-                <p class="line">...verse line...</p>
-            </div>
-            <div class="linegroup">
-                <p class="line">...verse line...</p>
-                <p class="line">...verse line...</p>
-            </div>
-            <section id="poem3">
-                <h3>Section level 3</h3>
-                <p>Some text</p>
-                <section id="poem4">
-                    <h4>Section level 4</h4>
+    <body>
+        <section epub:type="bodymatter part" id="poem-part">
+            <h1>Poem test</h1>
+            <section epub:type="z3998:poem" class="poem" id="poem1">
+                <h2>Poem headline</h2>
+                <div class="linegroup">
+                    <p class="line">...verse line...</p>
+                    <p class="line">...verse line...</p>
+                </div>
+                <div class="linegroup">
+                    <p class="line">...verse line...</p>
+                    <p class="line">...verse line...</p>
+                </div>
+                <section id="poem3">
+                    <h3>Section level 3</h3>
                     <p>Some text</p>
-                    <section id="poem5">
-                        <h5>Section level 5</h5>
+                    <section id="poem4">
+                        <h4>Section level 4</h4>
                         <p>Some text</p>
-                        <section id="poem6">
-                            <h6>Section level 6</h6>
+                        <section id="poem5">
+                            <h5>Section level 5</h5>
                             <p>Some text</p>
+                            <section id="poem6">
+                                <h6>Section level 6</h6>
+                                <p>Some text</p>
+                            </section>
                         </section>
                     </section>
                 </section>

--- a/client/src/test/resources/valid2020/EPUB/C00000-10-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-10-chapter.xhtml
@@ -108,7 +108,7 @@
         <link rel="prev" href="C00000-11-conclusion.xhtml"/>
     </head>
     <body epub:type="bodymatter chapter" id="poem-part-chapter">
-        <h1>Chapter in poem part</h1>
+        <h2>Chapter in poem part</h2>
         <p>Should be a separate file in EPUB.</p>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-10-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-10-chapter.xhtml
@@ -107,8 +107,10 @@
         <link rel="prev" href="C00000-09-part.xhtml"/>
         <link rel="prev" href="C00000-11-conclusion.xhtml"/>
     </head>
-    <body epub:type="bodymatter chapter" id="poem-part-chapter">
-        <h2>Chapter in poem part</h2>
-        <p>Should be a separate file in EPUB.</p>
+    <body>
+        <section epub:type="bodymatter chapter" id="poem-part-chapter">
+            <h2>Chapter in poem part</h2>
+            <p>Should be a separate file in EPUB.</p>
+        </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
@@ -107,162 +107,164 @@
         <link rel="prev" href="C00000-10-chapter.xhtml" />
         <link rel="next" href="C00000-12-footnotes.xhtml" />
     </head>
-    <body id="d910e4160" epub:type="bodymatter conclusion">
-        <h1 id="d910e4162">5. Discussion and conclusions</h1>
-        <p>
-            <span id="dtb936">In Chapter 1, I posed a number of questions. </span>
-            <span id="dtb937">Have I answered them successfully?</span>
-        </p>
-        <p>
-            <span id="dtb938">By contrasting information from different sources, I have managed to compile a biography of Valentin Haüy. </span>
-            <span id="dtb939">During my studies, further questions emerged:</span>
-        </p>
-        <p>
-            <span id="dtb940">- What factors can be said to have determined Haüy's abandoning his work as a translator and interpreter in order to dedicate his efforts to the education of the
-                blind?</span>
-        </p>
-        <p>
-            <span id="dtb941">My answer is: There were probably several factors involved. </span>
-            <span id="dtb942">We can assume that the first proof Haüy had that the disabled were educable was when he witnessed deaf pupils from the abbé l'épée's institute performing in public. </span>
-            <span id="dtb943">As he himself said, his encounter with the blind musicians at the St Ovid market was of decisive importance to his commitment to the blind. </span>
-            <span id="dtb944">That incident may in fact be seen as an epiphany (moment of revelation), a turning-point in Haüy's life. </span>
-            <span id="dtb945">Another such critical incident was his meeting with Lésueur. </span>
-            <span id="dtb946">Denzin (1989) in Engström (1995), describes epiphanies as "interactional moments and experiences which leave marks on people's lives".</span>
-        </p>
-        <p>
-            <span id="dtb947">- What is the characteristic feature of Haüy's life?</span>
-        </p>
-        <p>
-            <span id="dtb948">If I dared to classify Haüy's life at all, I would say that in many ways it was dramatic. </span>
-            <span id="dtb949">Initially, Haüy appears to have been a monarchist, but at the same time he belonged to the Age of Enlightenment. </span>
-            <span id="dtb950">Louis XVI was his benefactor, and in fact Haüy's pedagogic work, Essai sur l'education des aveugles, is dedicated to him. </span>
-            <span id="dtb951">Later, Haüy became an active revolutionary. </span>
-            <span id="dtb952">But is this so remarkable? </span>
-            <span id="d910e4242">
-                <span id="dtb953">He moved in precisely those circles - mainly composed of academics and public officials - from which the French Revolution sprang </span>
-                <a id="dtb954" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_98">98</a>
-                <span id="dtb955">.</span>
-            </span>
-        </p>
-        <p>
-            <span id="dtb956">Haüy's behaviour to Sicard was certainly not particularly friendly, but on the other hand, Sicard had his revenge when he denounced Haüy to the police. </span>
-            <span id="dtb957">In any case, it would seem that Haüy's activities during the French Revolution did not perturb Alexander I or Louis XVIII to any great degree.</span>
-        </p>
-        <p>
-            <span id="dtb958">Haüy was also a utilitarian (a term coined by Jeremy Bentham). </span>
-            <span id="dtb959">He believed wholeheartedly that the blind should taught to be self-sufficient. </span>
-            <span id="dtb960">This utilitarian view characterised teaching of the blind for a long time and is still the basis of education for the blind in the <abbr title="United States of America"
-                    id="d910e4274" epub:type="z3998:initialism" class="initialism">USA</abbr>, Canada and several Asian countries where the aim of the education for the blind is that they should
-                eventually be able to fend for themselves in life. </span>
-            <span id="d910e4278">
-                <span id="dtb961">Haüy does not stand alone amongst his contemporaries in taking this utilitarian view of education for the visually impaired: it was characteristic of all teaching
-                    during the period of the French Revolution </span>
-                <a id="dtb962" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_99">99</a>
-                <span id="dtb963">.</span>
-            </span>
-        </p>
-        <p>
-            <span id="dtb964">- Can we rightly call Haüy the father of education for the blind?</span>
-        </p>
-        <p>
-            <span id="dtb965">I have shown that experimentation in education for visually impaired pupils originated in several countries; there are thus several persons, contemporaries of Haüy, who
-                might well be called pioneers of education for the blind.</span>
-        </p>
-        <div id="page_27" class="page-normal" epub:type="pagebreak" title="27"></div>
-        <p>
-            <span id="dtb966">Pritchard (1963), however, emphasises that Haüy was unique in that he created a system of organised education for the blind based on a carefully thought-out method. </span>
-            <span id="dtb967">The outstanding feature of Haüy's enterprise - which sets him apart from British pedagogues of the time - was the founding of a school in the true sense, which imparted
-                free education to all blind children, regardless of sex or social class. </span>
-            <span id="dtb968">A pupil did not have to be rich or highly intelligent to be admitted to his school. </span>
-            <span id="dtb969">All previous attempts at educating the visually handicapped had been limited to children of well-to-do families and a few "blind child prodigies". </span>
-            <span id="dtb970">Haüy was also a pioneer of integration and equal opportunities. </span>
-            <span id="dtb971">At the Paris institute, blind and sighted children were taught side by side. </span>
-            <span id="dtb972">Haüy was convinced that his blind pupils, in time, would be capable of teaching the sighted. </span>
-            <span id="dtb973">Furthermore, Haüy's methods involved co-education, which must be considered quite radical for the time. </span>
-            <span id="dtb974">Haüy was, too, a pioneer of education for young children; he was teaching small children at the Musée des Aveugles long before Fröbel founded his school at Kilham in
-                Germany in 1816. </span>
-            <span id="dtb975">The idea of integration crops up repeatedly in his Essai sur l'Education des Aveugles. </span>
-            <span id="dtb976">He insisted in postponing for as long as possible the use of special teaching aids for the blind in such subjects as arithmetic since he wished the blind and the sighted
-                to be taught together.</span>
-        </p>
-        <p>
-            <span id="dtb977">One of the most basic elements in the education of the blind is the teaching of reading and writing. </span>
-            <span id="dtb978">Today we describe visual impairment as "an information handicap". </span>
-            <span id="dtb979">Haüy's greatest claim to fame is that he genuinely attempted to solve this enormous obstacle to learning by producing raised print books.</span>
-        </p>
-        <p>
-            <span id="dtb980">Folke Johansen (1983) believes that Valentin Haüy's raised letters were very difficult to read, but that his printing method was a unique invention. </span>
-            <span id="dtb981">It remained in use until modern computer technology made it possible to produce tactile writing. </span>
-            <span id="d910e4364">
-                <span id="dtb982">Indeed, Haüy has sometimes been called "The Gutenberg of the Blind" </span>
-                <a id="dtb983" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_100">100</a>
-                <span id="dtb984">.</span>
-            </span>
-        </p>
-        <p>
-            <span id="d910e4379">
-                <span id="dtb985">Haüy was not a pioneer of object lessons for blind children, although he did continue what others before him had begun </span>
-                <a id="dtb986" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_101">101</a>
-                <span id="dtb987">. </span>
-            </span>
-            <span id="dtb988">He was more practical in his approach to the problems involved in educating blind children, producing useful material and equipment (such as his printing press) which he
-                exported to other institutes for the blind in Europe.</span>
-        </p>
-        <p>
-            <span id="dtb989">Chapter 4 demonstrates Haüy's indirect influence on education for the blind in Sweden and Denmark in the early 19th century. </span>
-            <span id="dtb990">Pär Aron Borg was unwilling to recognise that he had learned anything from other pedagogues, although we find ample evidence that he was in fact influenced by Haüy. </span>
-            <span id="dtb991">In Denmark, Brorson consciously opposed Haüy's ideas when he refused to introduce his methods of teaching the blind to read and write. </span>
-            <span id="dtb992">In the wider perspective, however, it is clearly the case that Haüy's teaching methods formed the basis of the organised education of the blind which developed in the
-                Nordic countries in the 1850s and 1860s. </span>
-            <span id="dtb993">A general interest in the education of blind children in Sweden and Denmark is not evident, however, before the introduction of elementary schooling.</span>
-        </p>
-        <p>
-            <span id="dtb994">Pierre Henri (1987) suggests that Haüy's teaching methods were in many aspects rather naïve and indicated serious deficiencies in his knowledge of the blind. </span>
-            <span id="dtb995">Henri underlines the fact that Haüy's successor and critic, Guillé, in his Essai sur l'instruction des aveugles, ou exposé analytique des procédés employés pour les
-                instruire (1819) developed a much more sophisticated theoretical approach to the education of the blind. </span>
-            <span id="d910e4422">
-                <span id="dtb996">While he was director of the institute, however, Guillé did not increase the number of textbooks or teaching aids for use in object lessons </span>
-                <a id="dtb997" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_102">102</a>
-                <span id="dtb998">.</span>
-            </span>
-        </p>
-        <div id="page_28" class="page-normal" epub:type="pagebreak" title="28"></div>
-        <p>
-            <span id="dtb999">Then we come to the question: Did Haüy in fact found an institute for the blind in St Petersburg?</span>
-        </p>
-        <p>
-            <span id="dtb1000">It is clear that during his stay in Russia Haüy did found a school for the blind in St Petersburg in spite of considerable difficulties, one of which was the fact that
-                he had no knowledge of the Russian language. </span>
-            <span id="dtb1001">I ask myself how a man who was said to possess a gift for languages and who was fluent, it was also said, in ten or so modern languages, could have travelled to Russia
-                without knowing any Russian, although it is possible that he learned the language during the period which Skrébitsky was unable to document (1811-1817). </span>
-            <span id="dtb1002">It is highly probable that Haüy's difficulties in Russia were in fact caused by his lack of knowledge of Russian and by the fact that he was not familiar with the
-                religion or culture of that country. </span>
-            <span id="dtb1003">One illustration of his lack of knowledge of Russian society is that he tried to teach blind students to play the organ while in St Petersburg, in his ignorance of the
-                fact that organ music does not form part of the Greek Orthodox Church's rites. </span>
-            <span id="dtb1004">Skrébitsky (1884) also believes that Haüy was completely taken in by the public officials at the ministry and became a victim of Russian bureaucracy.</span>
-        </p>
-        <p>
-            <span id="dtb1005">Skrébitsky proves that Haüy brought his wife and son to Russia although he never requested any extra travel allowance for them. </span>
-            <span id="dtb1006">Madame Haüy remains a mystery and it is impossible to judge her contribution as a teacher. </span>
-            <span id="d910e4470">
-                <span id="dtb1007">All we know is that she taught at both the Musée des Aveugles </span>
-                <a id="dtb1008" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_103">103</a>
-                <span id="dtb1009"> and the institute in St Petersburg.</span>
-            </span>
-        </p>
-        <p>
-            <span id="dtb1010">Finally, I am convinced that this brief outline of the life of Valentin Haüy demonstrates beyond doubt his importance in the history of education of the blind and that
-                he is truly worthy to be called "the father of education for the blind".</span>
-        </p>
-        <p>
-            <span id="dtb1011">The Riksdag (Swedish parliament) and the government's policy concerning handicapped children towards the end of the 1970s and early 1980s stated, amongst other things,
-                that the latter should be integrated into the general educational system. </span>
-            <span id="dtb1012">Underlying this policy is a belief in equality and fraternity, two of the fundamental values of the Enlightenment. </span>
-            <span id="dtb1013">The Swedish government recently presented the draft of a proposed law (pro. 1999/2000:79) to the Riksdag: Från patient till medborgare - en nationell handlingsplan för
-                handikappolitiken (From patient to citizen - a national policy for the handicapped). </span>
-            <span id="dtb1014">This was a consequence of Sweden's adoption of the <abbr title="United Nations" id="d910e4503" epub:type="z3998:initialism" class="initialism">UN</abbr> standard
-                legislation on the right of the handicapped to participation and equality and other amendments to the Declaration of Human Rights. </span>
-            <span id="dtb1015">Haüy's ideas on integration and participation in society were thus strikingly modern.</span>
-        </p>
+    <body>
+        <section id="d910e4160" epub:type="bodymatter conclusion">
+            <h1 id="d910e4162">5. Discussion and conclusions</h1>
+            <p>
+                <span id="dtb936">In Chapter 1, I posed a number of questions. </span>
+                <span id="dtb937">Have I answered them successfully?</span>
+            </p>
+            <p>
+                <span id="dtb938">By contrasting information from different sources, I have managed to compile a biography of Valentin Haüy. </span>
+                <span id="dtb939">During my studies, further questions emerged:</span>
+            </p>
+            <p>
+                <span id="dtb940">- What factors can be said to have determined Haüy's abandoning his work as a translator and interpreter in order to dedicate his efforts to the education of the
+                    blind?</span>
+            </p>
+            <p>
+                <span id="dtb941">My answer is: There were probably several factors involved. </span>
+                <span id="dtb942">We can assume that the first proof Haüy had that the disabled were educable was when he witnessed deaf pupils from the abbé l'épée's institute performing in public. </span>
+                <span id="dtb943">As he himself said, his encounter with the blind musicians at the St Ovid market was of decisive importance to his commitment to the blind. </span>
+                <span id="dtb944">That incident may in fact be seen as an epiphany (moment of revelation), a turning-point in Haüy's life. </span>
+                <span id="dtb945">Another such critical incident was his meeting with Lésueur. </span>
+                <span id="dtb946">Denzin (1989) in Engström (1995), describes epiphanies as "interactional moments and experiences which leave marks on people's lives".</span>
+            </p>
+            <p>
+                <span id="dtb947">- What is the characteristic feature of Haüy's life?</span>
+            </p>
+            <p>
+                <span id="dtb948">If I dared to classify Haüy's life at all, I would say that in many ways it was dramatic. </span>
+                <span id="dtb949">Initially, Haüy appears to have been a monarchist, but at the same time he belonged to the Age of Enlightenment. </span>
+                <span id="dtb950">Louis XVI was his benefactor, and in fact Haüy's pedagogic work, Essai sur l'education des aveugles, is dedicated to him. </span>
+                <span id="dtb951">Later, Haüy became an active revolutionary. </span>
+                <span id="dtb952">But is this so remarkable? </span>
+                <span id="d910e4242">
+                    <span id="dtb953">He moved in precisely those circles - mainly composed of academics and public officials - from which the French Revolution sprang </span>
+                    <a id="dtb954" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_98">98</a>
+                    <span id="dtb955">.</span>
+                </span>
+            </p>
+            <p>
+                <span id="dtb956">Haüy's behaviour to Sicard was certainly not particularly friendly, but on the other hand, Sicard had his revenge when he denounced Haüy to the police. </span>
+                <span id="dtb957">In any case, it would seem that Haüy's activities during the French Revolution did not perturb Alexander I or Louis XVIII to any great degree.</span>
+            </p>
+            <p>
+                <span id="dtb958">Haüy was also a utilitarian (a term coined by Jeremy Bentham). </span>
+                <span id="dtb959">He believed wholeheartedly that the blind should taught to be self-sufficient. </span>
+                <span id="dtb960">This utilitarian view characterised teaching of the blind for a long time and is still the basis of education for the blind in the <abbr title="United States of America"
+                        id="d910e4274" epub:type="z3998:initialism" class="initialism">USA</abbr>, Canada and several Asian countries where the aim of the education for the blind is that they should
+                    eventually be able to fend for themselves in life. </span>
+                <span id="d910e4278">
+                    <span id="dtb961">Haüy does not stand alone amongst his contemporaries in taking this utilitarian view of education for the visually impaired: it was characteristic of all teaching
+                        during the period of the French Revolution </span>
+                    <a id="dtb962" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_99">99</a>
+                    <span id="dtb963">.</span>
+                </span>
+            </p>
+            <p>
+                <span id="dtb964">- Can we rightly call Haüy the father of education for the blind?</span>
+            </p>
+            <p>
+                <span id="dtb965">I have shown that experimentation in education for visually impaired pupils originated in several countries; there are thus several persons, contemporaries of Haüy, who
+                    might well be called pioneers of education for the blind.</span>
+            </p>
+            <div id="page_27" class="page-normal" epub:type="pagebreak" title="27"></div>
+            <p>
+                <span id="dtb966">Pritchard (1963), however, emphasises that Haüy was unique in that he created a system of organised education for the blind based on a carefully thought-out method. </span>
+                <span id="dtb967">The outstanding feature of Haüy's enterprise - which sets him apart from British pedagogues of the time - was the founding of a school in the true sense, which imparted
+                    free education to all blind children, regardless of sex or social class. </span>
+                <span id="dtb968">A pupil did not have to be rich or highly intelligent to be admitted to his school. </span>
+                <span id="dtb969">All previous attempts at educating the visually handicapped had been limited to children of well-to-do families and a few "blind child prodigies". </span>
+                <span id="dtb970">Haüy was also a pioneer of integration and equal opportunities. </span>
+                <span id="dtb971">At the Paris institute, blind and sighted children were taught side by side. </span>
+                <span id="dtb972">Haüy was convinced that his blind pupils, in time, would be capable of teaching the sighted. </span>
+                <span id="dtb973">Furthermore, Haüy's methods involved co-education, which must be considered quite radical for the time. </span>
+                <span id="dtb974">Haüy was, too, a pioneer of education for young children; he was teaching small children at the Musée des Aveugles long before Fröbel founded his school at Kilham in
+                    Germany in 1816. </span>
+                <span id="dtb975">The idea of integration crops up repeatedly in his Essai sur l'Education des Aveugles. </span>
+                <span id="dtb976">He insisted in postponing for as long as possible the use of special teaching aids for the blind in such subjects as arithmetic since he wished the blind and the sighted
+                    to be taught together.</span>
+            </p>
+            <p>
+                <span id="dtb977">One of the most basic elements in the education of the blind is the teaching of reading and writing. </span>
+                <span id="dtb978">Today we describe visual impairment as "an information handicap". </span>
+                <span id="dtb979">Haüy's greatest claim to fame is that he genuinely attempted to solve this enormous obstacle to learning by producing raised print books.</span>
+            </p>
+            <p>
+                <span id="dtb980">Folke Johansen (1983) believes that Valentin Haüy's raised letters were very difficult to read, but that his printing method was a unique invention. </span>
+                <span id="dtb981">It remained in use until modern computer technology made it possible to produce tactile writing. </span>
+                <span id="d910e4364">
+                    <span id="dtb982">Indeed, Haüy has sometimes been called "The Gutenberg of the Blind" </span>
+                    <a id="dtb983" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_100">100</a>
+                    <span id="dtb984">.</span>
+                </span>
+            </p>
+            <p>
+                <span id="d910e4379">
+                    <span id="dtb985">Haüy was not a pioneer of object lessons for blind children, although he did continue what others before him had begun </span>
+                    <a id="dtb986" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_101">101</a>
+                    <span id="dtb987">. </span>
+                </span>
+                <span id="dtb988">He was more practical in his approach to the problems involved in educating blind children, producing useful material and equipment (such as his printing press) which he
+                    exported to other institutes for the blind in Europe.</span>
+            </p>
+            <p>
+                <span id="dtb989">Chapter 4 demonstrates Haüy's indirect influence on education for the blind in Sweden and Denmark in the early 19th century. </span>
+                <span id="dtb990">Pär Aron Borg was unwilling to recognise that he had learned anything from other pedagogues, although we find ample evidence that he was in fact influenced by Haüy. </span>
+                <span id="dtb991">In Denmark, Brorson consciously opposed Haüy's ideas when he refused to introduce his methods of teaching the blind to read and write. </span>
+                <span id="dtb992">In the wider perspective, however, it is clearly the case that Haüy's teaching methods formed the basis of the organised education of the blind which developed in the
+                    Nordic countries in the 1850s and 1860s. </span>
+                <span id="dtb993">A general interest in the education of blind children in Sweden and Denmark is not evident, however, before the introduction of elementary schooling.</span>
+            </p>
+            <p>
+                <span id="dtb994">Pierre Henri (1987) suggests that Haüy's teaching methods were in many aspects rather naïve and indicated serious deficiencies in his knowledge of the blind. </span>
+                <span id="dtb995">Henri underlines the fact that Haüy's successor and critic, Guillé, in his Essai sur l'instruction des aveugles, ou exposé analytique des procédés employés pour les
+                    instruire (1819) developed a much more sophisticated theoretical approach to the education of the blind. </span>
+                <span id="d910e4422">
+                    <span id="dtb996">While he was director of the institute, however, Guillé did not increase the number of textbooks or teaching aids for use in object lessons </span>
+                    <a id="dtb997" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_102">102</a>
+                    <span id="dtb998">.</span>
+                </span>
+            </p>
+            <div id="page_28" class="page-normal" epub:type="pagebreak" title="28"></div>
+            <p>
+                <span id="dtb999">Then we come to the question: Did Haüy in fact found an institute for the blind in St Petersburg?</span>
+            </p>
+            <p>
+                <span id="dtb1000">It is clear that during his stay in Russia Haüy did found a school for the blind in St Petersburg in spite of considerable difficulties, one of which was the fact that
+                    he had no knowledge of the Russian language. </span>
+                <span id="dtb1001">I ask myself how a man who was said to possess a gift for languages and who was fluent, it was also said, in ten or so modern languages, could have travelled to Russia
+                    without knowing any Russian, although it is possible that he learned the language during the period which Skrébitsky was unable to document (1811-1817). </span>
+                <span id="dtb1002">It is highly probable that Haüy's difficulties in Russia were in fact caused by his lack of knowledge of Russian and by the fact that he was not familiar with the
+                    religion or culture of that country. </span>
+                <span id="dtb1003">One illustration of his lack of knowledge of Russian society is that he tried to teach blind students to play the organ while in St Petersburg, in his ignorance of the
+                    fact that organ music does not form part of the Greek Orthodox Church's rites. </span>
+                <span id="dtb1004">Skrébitsky (1884) also believes that Haüy was completely taken in by the public officials at the ministry and became a victim of Russian bureaucracy.</span>
+            </p>
+            <p>
+                <span id="dtb1005">Skrébitsky proves that Haüy brought his wife and son to Russia although he never requested any extra travel allowance for them. </span>
+                <span id="dtb1006">Madame Haüy remains a mystery and it is impossible to judge her contribution as a teacher. </span>
+                <span id="d910e4470">
+                    <span id="dtb1007">All we know is that she taught at both the Musée des Aveugles </span>
+                    <a id="dtb1008" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_103">103</a>
+                    <span id="dtb1009"> and the institute in St Petersburg.</span>
+                </span>
+            </p>
+            <p>
+                <span id="dtb1010">Finally, I am convinced that this brief outline of the life of Valentin Haüy demonstrates beyond doubt his importance in the history of education of the blind and that
+                    he is truly worthy to be called "the father of education for the blind".</span>
+            </p>
+            <p>
+                <span id="dtb1011">The Riksdag (Swedish parliament) and the government's policy concerning handicapped children towards the end of the 1970s and early 1980s stated, amongst other things,
+                    that the latter should be integrated into the general educational system. </span>
+                <span id="dtb1012">Underlying this policy is a belief in equality and fraternity, two of the fundamental values of the Enlightenment. </span>
+                <span id="dtb1013">The Swedish government recently presented the draft of a proposed law (pro. 1999/2000:79) to the Riksdag: Från patient till medborgare - en nationell handlingsplan för
+                    handikappolitiken (From patient to citizen - a national policy for the handicapped). </span>
+                <span id="dtb1014">This was a consequence of Sweden's adoption of the <abbr title="United Nations" id="d910e4503" epub:type="z3998:initialism" class="initialism">UN</abbr> standard
+                    legislation on the right of the handicapped to participation and equality and other amendments to the Declaration of Human Rights. </span>
+                <span id="dtb1015">Haüy's ideas on integration and participation in society were thus strikingly modern.</span>
+            </p>
+        </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-13-part.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-13-part.xhtml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.daisy.org/pipeline/modules/nordic/nordic-html5.rng"?>
+<?xml-model href="http://www.daisy.org/pipeline/modules/nordic/nordic2015-1.sch"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#"
+    xmlns:nordic="http://www.mtm.se/epub/">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Valentin Haüy - the father of the education for the blind</title>
+        <meta content="C00000" name="dc:identifier" />
+        <meta name="viewport" content="width=device-width" />
+        <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
+    </head>
+    <body epub:type="bodymatter part" id="test-part">
+        <h1>Part title</h1>
+        <p>Part testing in different files</p>
+    </body>
+</html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-13-part.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-13-part.xhtml
@@ -11,8 +11,10 @@
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
     </head>
-    <body epub:type="bodymatter part" id="test-part">
-        <h1>Part title</h1>
-        <p>Part testing in different files</p>
+    <body>
+        <section epub:type="bodymatter part" id="test-part">
+            <h1>Part title</h1>
+            <p>Part testing in different files</p>
+        </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-14-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-14-chapter.xhtml
@@ -11,8 +11,10 @@
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
     </head>
-    <body epub:type="bodymatter chapter" id="test-chapter">
-        <h2>Chapter title</h2>
-        <p>Chapter testing in different files</p>
+    <body>
+        <section epub:type="bodymatter chapter" id="test-chapter">
+            <h2>Chapter title</h2>
+            <p>Chapter testing in different files</p>
+        </section>
     </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-14-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-14-chapter.xhtml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.daisy.org/pipeline/modules/nordic/nordic-html5.rng"?>
+<?xml-model href="http://www.daisy.org/pipeline/modules/nordic/nordic2015-1.sch"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#"
+    xmlns:nordic="http://www.mtm.se/epub/">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Valentin Haüy - the father of the education for the blind</title>
+        <meta content="C00000" name="dc:identifier" />
+        <meta name="viewport" content="width=device-width" />
+        <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>
+    </head>
+    <body epub:type="bodymatter chapter" id="test-chapter">
+        <h2>Chapter title</h2>
+        <p>Chapter testing in different files</p>
+    </body>
+</html>

--- a/client/src/test/resources/valid2020/EPUB/nav.ncx
+++ b/client/src/test/resources/valid2020/EPUB/nav.ncx
@@ -175,19 +175,19 @@
                 </navLabel>
                 <content src="C00000-06-chapter.xhtml#d910e3633"/>
             </navPoint>
-            <navPoint id="navPoint-26" playOrder="26">
-                <navLabel>
-                    <text>Rearmatter</text>
-                </navLabel>
-                <content src="C00000-07-rearnotes.xhtml#rearnotes_body"/>
-				<navPoint id="navPoint-27" playOrder="27">
-					<navLabel>
-						<text>End notes</text>
-					</navLabel>
-					<content src="C00000-07-rearnotes.xhtml#endnote_section"/>
-				</navPoint>
-            </navPoint>
         </navPoint>
+		<navPoint id="navPoint-26" playOrder="26">
+			<navLabel>
+				<text>Rearmatter</text>
+			</navLabel>
+			<content src="C00000-07-rearnotes.xhtml#rearnotes_body"/>
+			<navPoint id="navPoint-27" playOrder="27">
+				<navLabel>
+					<text>End notes</text>
+				</navLabel>
+				<content src="C00000-07-rearnotes.xhtml#endnote_section"/>
+			</navPoint>
+		</navPoint>
         <navPoint id="navPoint-28" playOrder="28">
             <navLabel>
                 <text>4. The importance of Haüy in the education of the blind in Sweden and elsewhere extra long title extra long title extra long title extra long title</text>
@@ -290,6 +290,18 @@
 				</navPoint>
             </navPoint>
         </navPoint>
+		<navPoint id="navPoint-16" playOrder="16">
+			<navLabel>
+				<text>Part title</text>
+			</navLabel>
+			<content src="C00000-13-part.xhtml#test-part"/>
+            <navPoint id="navPoint-16" playOrder="16">
+                <navLabel>
+                    <text>Chapter title</text>
+                </navLabel>
+                <content src="C00000-14-chapter.xhtml#test-chapter"/>
+            </navPoint>
+		</navPoint>
     </navMap>
     <pageList>
         <navLabel>
@@ -547,5 +559,6 @@
             </navLabel>
             <content src="C00000-12-toc.xhtml#page-164"/>
         </pageTarget>
+
     </pageList>
 </ncx>

--- a/client/src/test/resources/valid2020/EPUB/nav.ncx
+++ b/client/src/test/resources/valid2020/EPUB/nav.ncx
@@ -55,18 +55,18 @@
                 <text>1. Research questions</text>
             </navLabel>
             <content src="C00000-04-chapter.xhtml#d910e694"/>
-			<navPoint id="navPoint-7" playOrder="7">
-				<navLabel>
-					<text>A chapter without heading.</text>
-				</navLabel>
-				<content src="C00000-04-chapter.xhtml#d6e157"/>
-				<navPoint id="navPoint-7" playOrder="7">
-					<navLabel>
-						<text>Some chapter</text>
-					</navLabel>
-					<content src="C00000-04-chapter.xhtml#d6e160"/>
-				</navPoint>
-			</navPoint>
+            <navPoint id="navPoint-7" playOrder="7">
+                <navLabel>
+                    <text>A chapter without heading.</text>
+                </navLabel>
+                <content src="C00000-04-chapter.xhtml#d6e157"/>
+                <navPoint id="navPoint-7" playOrder="7">
+                    <navLabel>
+                        <text>Some chapter</text>
+                    </navLabel>
+                    <content src="C00000-04-chapter.xhtml#d6e160"/>
+                </navPoint>
+            </navPoint>
         </navPoint>
         <navPoint id="navPoint-8" playOrder="8">
             <navLabel>
@@ -176,18 +176,18 @@
                 <content src="C00000-06-chapter.xhtml#d910e3633"/>
             </navPoint>
         </navPoint>
-		<navPoint id="navPoint-26" playOrder="26">
-			<navLabel>
-				<text>Rearmatter</text>
-			</navLabel>
-			<content src="C00000-07-rearnotes.xhtml#rearnotes_body"/>
-			<navPoint id="navPoint-27" playOrder="27">
-				<navLabel>
-					<text>End notes</text>
-				</navLabel>
-				<content src="C00000-07-rearnotes.xhtml#endnote_section"/>
-			</navPoint>
-		</navPoint>
+        <navPoint id="navPoint-26" playOrder="26">
+            <navLabel>
+                <text>Rearmatter</text>
+            </navLabel>
+            <content src="C00000-07-rearnotes.xhtml#rearnotes_body"/>
+            <navPoint id="navPoint-27" playOrder="27">
+                <navLabel>
+                    <text>End notes</text>
+                </navLabel>
+                <content src="C00000-07-rearnotes.xhtml#endnote_section"/>
+            </navPoint>
+        </navPoint>
         <navPoint id="navPoint-28" playOrder="28">
             <navLabel>
                 <text>4. The importance of Haüy in the education of the blind in Sweden and elsewhere extra long title extra long title extra long title extra long title</text>
@@ -204,30 +204,30 @@
                     <text>Poem headline</text>
                 </navLabel>
                 <content src="C00000-09-part.xhtml#poem1"/>
-				<navPoint id="navPoint-31" playOrder="31">
-					<navLabel>
-						<text>Section level 3</text>
-					</navLabel>
-					<content src="C00000-09-part.xhtml#poem3"/>
-					<navPoint id="navPoint-32" playOrder="32">
-						<navLabel>
-							<text>Section level 4</text>
-						</navLabel>
-						<content src="C00000-09-part.xhtml#poem4"/>
-						<navPoint id="navPoint-33" playOrder="33">
-							<navLabel>
-								<text>Section level 5</text>
-							</navLabel>
-							<content src="C00000-09-part.xhtml#poem5"/>
-							<navPoint id="navPoint-34" playOrder="34">
-								<navLabel>
-									<text>Section level 6</text>
-								</navLabel>
-								<content src="C00000-09-part.xhtml#poem6"/>
-							</navPoint>
-						</navPoint>
-					</navPoint>
-				</navPoint>
+                <navPoint id="navPoint-31" playOrder="31">
+                    <navLabel>
+                        <text>Section level 3</text>
+                    </navLabel>
+                    <content src="C00000-09-part.xhtml#poem3"/>
+                    <navPoint id="navPoint-32" playOrder="32">
+                        <navLabel>
+                            <text>Section level 4</text>
+                        </navLabel>
+                        <content src="C00000-09-part.xhtml#poem4"/>
+                        <navPoint id="navPoint-33" playOrder="33">
+                            <navLabel>
+                                <text>Section level 5</text>
+                            </navLabel>
+                            <content src="C00000-09-part.xhtml#poem5"/>
+                            <navPoint id="navPoint-34" playOrder="34">
+                                <navLabel>
+                                    <text>Section level 6</text>
+                                </navLabel>
+                                <content src="C00000-09-part.xhtml#poem6"/>
+                            </navPoint>
+                        </navPoint>
+                    </navPoint>
+                </navPoint>
             </navPoint>
             <navPoint id="navPoint-30" playOrder="30">
                 <navLabel>
@@ -252,56 +252,56 @@
                     <text>START: FULL LICENSE</text>
                 </navLabel>
                 <content src="C00000-12-toc.xhtml#level2_8"/>
-				<navPoint id="navPoint-33" playOrder="33">
-					<navLabel>
-						<text>Section 1. General Terms of Use and Redistributing Project Gutenberg-tm electronic works</text>
-					</navLabel>
-					<content src="C00000-12-toc.xhtml#level3_4"/>
-					<navPoint id="navPoint-33" playOrder="33">
-						<navLabel>
-							<text>1.F.</text>
-						</navLabel>
-						<content src="C00000-12-toc.xhtml#level4_1"/>
-					</navPoint>
-				</navPoint>
-				<navPoint id="navPoint-33" playOrder="33">
-					<navLabel>
-						<text>Section 2. Information about the Mission of Project Gutenberg-tm</text>
-					</navLabel>
-					<content src="C00000-12-toc.xhtml#level3_5"/>
-				</navPoint>
-				<navPoint id="navPoint-33" playOrder="33">
-					<navLabel>
-						<text>Section 3. Information about the Project Gutenberg Literary Archive Foundation</text>
-					</navLabel>
-					<content src="C00000-12-toc.xhtml#level3_6"/>
-				</navPoint>
-				<navPoint id="navPoint-33" playOrder="33">
-					<navLabel>
-						<text>Section 4. Information about Donations to the Project Gutenberg Literary Archive Foundation</text>
-					</navLabel>
-					<content src="C00000-12-toc.xhtml#level3_7"/>
-				</navPoint>
-				<navPoint id="navPoint-33" playOrder="33">
-					<navLabel>
-						<text>Section 5. General Information About Project Gutenberg-tm electronic works.</text>
-					</navLabel>
-					<content src="C00000-12-toc.xhtml#level3_8"/>
-				</navPoint>
+                <navPoint id="navPoint-33" playOrder="33">
+                    <navLabel>
+                        <text>Section 1. General Terms of Use and Redistributing Project Gutenberg-tm electronic works</text>
+                    </navLabel>
+                    <content src="C00000-12-toc.xhtml#level3_4"/>
+                    <navPoint id="navPoint-33" playOrder="33">
+                        <navLabel>
+                            <text>1.F.</text>
+                        </navLabel>
+                        <content src="C00000-12-toc.xhtml#level4_1"/>
+                    </navPoint>
+                </navPoint>
+                <navPoint id="navPoint-33" playOrder="33">
+                    <navLabel>
+                        <text>Section 2. Information about the Mission of Project Gutenberg-tm</text>
+                    </navLabel>
+                    <content src="C00000-12-toc.xhtml#level3_5"/>
+                </navPoint>
+                <navPoint id="navPoint-33" playOrder="33">
+                    <navLabel>
+                        <text>Section 3. Information about the Project Gutenberg Literary Archive Foundation</text>
+                    </navLabel>
+                    <content src="C00000-12-toc.xhtml#level3_6"/>
+                </navPoint>
+                <navPoint id="navPoint-33" playOrder="33">
+                    <navLabel>
+                        <text>Section 4. Information about Donations to the Project Gutenberg Literary Archive Foundation</text>
+                    </navLabel>
+                    <content src="C00000-12-toc.xhtml#level3_7"/>
+                </navPoint>
+                <navPoint id="navPoint-33" playOrder="33">
+                    <navLabel>
+                        <text>Section 5. General Information About Project Gutenberg-tm electronic works.</text>
+                    </navLabel>
+                    <content src="C00000-12-toc.xhtml#level3_8"/>
+                </navPoint>
             </navPoint>
         </navPoint>
-		<navPoint id="navPoint-16" playOrder="16">
-			<navLabel>
-				<text>Part title</text>
-			</navLabel>
-			<content src="C00000-13-part.xhtml#test-part"/>
+        <navPoint id="navPoint-16" playOrder="16">
+            <navLabel>
+                <text>Part title</text>
+            </navLabel>
+            <content src="C00000-13-part.xhtml#test-part"/>
             <navPoint id="navPoint-16" playOrder="16">
                 <navLabel>
                     <text>Chapter title</text>
                 </navLabel>
                 <content src="C00000-14-chapter.xhtml#test-chapter"/>
             </navPoint>
-		</navPoint>
+        </navPoint>
     </navMap>
     <pageList>
         <navLabel>

--- a/client/src/test/resources/valid2020/EPUB/nav.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/nav.xhtml
@@ -158,17 +158,17 @@
                                 <span>3.11 The final years</span>
                             </a>
                         </li>
+                    </ol>
+                </li>
+                <li>
+                    <a href="C00000-07-rearnotes.xhtml#rearnotes_body">
+                        <span>Rearnotes</span>
+                    </a>
+                    <ol>
                         <li>
-                            <a href="C00000-07-rearnotes.xhtml#rearnotes_body">
-                                <span>Rearnotes</span>
+                            <a href="C00000-07-rearnotes.xhtml#endnote_section">
+                                <span>End Notes</span>
                             </a>
-                            <ol>
-                                <li>
-                                    <a href="C00000-07-rearnotes.xhtml#endnote_section">
-                                        <span>End Notes</span>
-                                    </a>
-                                </li>
-                            </ol>
                         </li>
                     </ol>
                 </li>
@@ -253,6 +253,18 @@
                                     <a href="C00000-12-toc.xhtml#level3_8">Section 5. General Information About Project Gutenberg-tm electronic works.</a>
                                 </li>
                             </ol>
+                        </li>
+                    </ol>
+                </li>
+                <li>
+                    <a href="C00000-13-part.xhtml#test-part">
+                        <span>Part title</span>
+                    </a>
+                    <ol>
+                        <li>
+                            <a href="C00000-14-chapter.xhtml#test-chapter">
+                                <span>Chapter title</span>
+                            </a>
                         </li>
                     </ol>
                 </li>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-references.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.nav-references.sch
@@ -125,18 +125,11 @@
             <let name="document-in-nav" value="((preceding::html:a | self::*) intersect ancestor::html:nav//html:a)[substring-before(@href,'#') = $href][1]"/>
             <let name="document-in-nav-depth" value="count($document-in-nav/ancestor::html:li)"/>
             <let name="depth-in-nav" value="count(ancestor::html:li)"/>
-
-            <let name="result-chapter-epub" value="if ($result-ref-first[tokenize(@data-document-epub-type,'\s+')='chapter']) then 1 else 0"/>
-            <let name="result-chapter-role" value="if ($result-ref-first[@data-document-role='doc-chapter']) then 1 else 0"/>
-            <let name="result-after-part-epub" value="if ($result-ref-first/preceding-sibling::c:result[tokenize(@data-document-epub-type,'\s+')='part']) then 1 else 0"/>
-            <let name="result-after-part-role" value="if ($result-ref-first/preceding-sibling::c:result[@data-document-role='doc-part']) then 1 else 0"/>
-            <let name="result-chapter-after-part" value="if (($result-chapter-epub=1 and $result-after-part-epub=1) or ($result-chapter-role=1 and $result-after-part-role=1)) then 1 else 0"/>
-
             <let name="depth-in-content" value="$result-ref-first/xs:integer((@data-heading-depth, @data-sectioning-depth)[1])"/>
 
-            <assert test="not($result-ref-first) or $depth-in-nav = $depth-in-content + $document-in-nav-depth - 1 - $result-chapter-after-part">[nordic_nav_references_2b] The nesting of headlines in the content does not match the
+            <assert test="not($result-ref-first) or $depth-in-nav = $depth-in-content">[nordic_nav_references_2b] The nesting of headlines in the content does not match the
                 nesting of headlines in the navigation document. The toc item `<value-of select="$context"/>` in the navigation document is not nested at the correct
-                level. The referenced document (<value-of select="$href"/>) occurs in the navigation document at nesting depth <value-of select="$document-in-nav-depth - $result-chapter-after-part"/> (<value-of
+                level. The referenced document (<value-of select="$href"/>) occurs in the navigation document at nesting depth <value-of select="$document-in-nav-depth"/> (<value-of
                     select="if ($document-in-nav-depth = 1) then 'it is not contained inside other sections such as a part or a chapter'
                     else concat('it is contained inside ',string-join($document-in-nav/ancestor::html:li[1]/ancestor::html:li/concat('&quot;',(text(),*[not(local-name()=('ol','ul'))]/string-join(.//text(),''))[normalize-space()][1],'&quot;'),', which is contained inside'))"
                 />). The referenced headline (<value-of select="@href"/>) occurs in the navigation document at nesting depth <value-of select="$depth-in-nav"/> (<value-of
@@ -144,7 +137,7 @@
                     else concat('it is contained inside ',string-join(ancestor::html:li[1]/ancestor::html:li/concat('&quot;',(text(),*/string-join(.//text(),''))[normalize-space()][1],'&quot;'),', which is contained inside'))"
                 />). The referenced headline (`&lt;<value-of select="$result-ref-first/@data-heading-element"/><value-of select="$result-ref-first/@data-heading-id/concat(' id=&quot;',.,'&quot;')"/>&gt;<value-of
                     select="$result-ref-first/text()"/>&lt;/<value-of select="$result-ref-first/@data-heading-element"/>&gt;) occurs in the content document <value-of select="$href"/> as a `<value-of
-                    select="$result-ref-first/@data-heading-element"/>` which implies that it should be referenced at nesting depth <value-of select="$depth-in-content + $document-in-nav-depth - 1 - $result-chapter-after-part"/> in the
+                    select="$result-ref-first/@data-heading-element"/>` which implies that it should be referenced at nesting depth <value-of select="$depth-in-content"/> in the
                 navigation document.</assert>
         </rule>
     </pattern>

--- a/src/test/resources/2020-1/X50525A/EPUB/X50525A-05-frontmatter.xhtml
+++ b/src/test/resources/2020-1/X50525A/EPUB/X50525A-05-frontmatter.xhtml
@@ -20,7 +20,7 @@
 <h2 id="h2_1">Ein Brief Friedrich Nietzsches zum Vorwort.</h2>
 <figure class="image-series">
 <figcaption>(Gedruckter text.)</figcaption>
-<figure id="imggroup_4" class="image" aria-describedby="desc-test01"><img id="img_4" src="images/X50525A-001.jpg" alt="Figur" />
+<figure id="imggroup_4" class="image"><img id="img_4" aria-describedby="desc-test01" src="images/X50525A-001.jpg" alt="Figur" />
 <aside class="fig-desc" id="desc-test01" lang="en" xml:lang="en">
 <p>[Placeholder for extracted text or an image description.]</p>
 </aside>


### PR DESCRIPTION
Hi @josteinaj 

In this PR I've updated the `list-heading-and-pagebreak-references.xsl` files in the client so we have the right input data to the other schema files. Not sure why these were diffing.

I also added a test case and changed the code to handle the occurrence when you have a part and chapter in different files. The logic was complicated there, and I don't see a reason for it. I also updated one of the test books as it was incorrect.

Last but not least, the test book X50525A was incorrect regarding aria-described-by for images. The tests must have failed before, but I have not seen them. So had to fix this, so the tests passed.

Best regards
Daniel