### PR TITLE
New EPUBCheck release.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.w3c</groupId>
             <artifactId>epubcheck</artifactId>
-            <version>4.2.6</version>
+            <version>5.0.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hi @josteinaj 

Yesterday EPUBCheck released the 5.0.0 version, this has been in development for a month and should contain a bugfix for a stack overflow issue MTM has in one larger book.

Best regards
Daniel