### PR TITLE
Updated to use Saxon 11 and update all schemas to XSLT 3.0

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -10,23 +10,23 @@ Create a new version of the tooling with the current schema you
 need to one dependency to convert the schema files to xslt.
 More over you need to download and install saxon-xslt.
 
-#### Download schxslt
+#### Checkout schxslt
 
-Download the latest release of `schxslt` and unpack it to the directory
+Clone the latest release of `schxslt` and into the directory
 `client/schxslt`.
 
-https://github.com/schxslt/schxslt/releases
+git clone https://github.com/schxslt/SchXslt2-Core .
 
 #### Installing saxon-xslt
 
 First you need to download the package from the site or find it in your distribution.
 
-https://www.saxonica.com/download/download_page.xml
+https://github.com/Saxonica/Saxon-HE/tree/main/11/Java
 
-Currently we use version 9 to run our conversion of the schema. Saxon is embedded in the executable
+Currently we use version 11 to run our conversion of the schema. Saxon is embedded in the executable
 so this is only needed during the build process.
 
-The executable the script is looking for is `saxon9-xslt`
+The executable the script is looking for is `saxon11-xslt`
 
 #### Update nordic guideline rules
 

--- a/client/createSchemas.sh
+++ b/client/createSchemas.sh
@@ -14,11 +14,11 @@ sed -i 's/<define name="annotation">/<define name="annotation" combine="choice">
 sed -i 's/<define name="list">/<define name="list" combine="choice">/' src/main/resources/2015-1/nordic-html5.rng
 sed -i '/<start combine="choice">/,/<\/start>/d' src/main/resources/2015-1/nordic-html5.rng
 
-saxon9-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.nav-ncx.sch -o:src/main/resources/2015-1/nordic2015-1.nav-ncx.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.nav-references.sch -o:src/main/resources/2015-1/nordic2015-1.nav-references.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.opf-and-html.sch -o:src/main/resources/2015-1/nordic2015-1.opf-and-html.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.opf.sch -o:src/main/resources/2015-1/nordic2015-1.opf.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.sch -o:src/main/resources/2015-1/nordic2015-1.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.nav-ncx.sch -o:src/main/resources/2015-1/nordic2015-1.nav-ncx.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.nav-references.sch -o:src/main/resources/2015-1/nordic2015-1.nav-references.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.opf-and-html.sch -o:src/main/resources/2015-1/nordic2015-1.opf-and-html.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.opf.sch -o:src/main/resources/2015-1/nordic2015-1.opf.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2015-1/nordic2015-1.sch -o:src/main/resources/2015-1/nordic2015-1.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
 
 cp $SCHEMA_PATH/2020-1/nordic-html5.rng src/main/resources/2020-1
 sed -i 's/http:\/\/www.daisy.org\/pipeline\/modules\/mathml-utils\/mathml3.rng/mathml3.rng/' src/main/resources/2020-1/nordic-html5.rng
@@ -26,14 +26,19 @@ sed -i 's/<define name="annotation">/<define name="annotation" combine="choice">
 sed -i 's/<define name="list">/<define name="list" combine="choice">/' src/main/resources/2020-1/nordic-html5.rng
 sed -i '/<start combine="choice">/,/<\/start>/d' src/main/resources/2020-1/nordic-html5.rng
 
-saxon9-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.nav-ncx.sch -o:src/main/resources/2020-1/nordic2020-1.nav-ncx.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.nav-references.sch -o:src/main/resources/2020-1/nordic2020-1.nav-references.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.opf-and-html.sch -o:src/main/resources/2020-1/nordic2020-1.opf-and-html.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.opf.sch -o:src/main/resources/2020-1/nordic2020-1.opf.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
-saxon9-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.sch -o:src/main/resources/2020-1/nordic2020-1.xsl -xsl:$SCHXSLT_PATH/2.0/compile-for-svrl.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.nav-ncx.sch -o:src/main/resources/2020-1/nordic2020-1.nav-ncx.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.nav-references.sch -o:src/main/resources/2020-1/nordic2020-1.nav-references.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.opf-and-html.sch -o:src/main/resources/2020-1/nordic2020-1.opf-and-html.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.opf.sch -o:src/main/resources/2020-1/nordic2020-1.opf.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:$SCHEMA_PATH/2020-1/nordic2020-1.sch -o:src/main/resources/2020-1/nordic2020-1.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
 
 
 mkdir -p src/main/resources/xslt/2015-1
 mkdir -p src/main/resources/xslt/2020-1
 cp $XSLT_PATH/2015-1/list-heading-and-pagebreak-references.xsl src/main/resources/xslt/2015-1
 cp $XSLT_PATH/2020-1/list-heading-and-pagebreak-references.xsl src/main/resources/xslt/2020-1
+
+
+mkdir -p src/main/resources/dtbook/compiled
+saxon11-xslt -s:src/main/resources/dtbook/sch/dtbook.mathml.nimas.sch -o:src/main/resources/dtbook/compiled/dtbook.mathml.nimas.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
+saxon11-xslt -s:src/main/resources/dtbook/sch/dtbook.mathml.sch -o:src/main/resources/dtbook/compiled/dtbook.mathml.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl

--- a/client/createSchemas.sh
+++ b/client/createSchemas.sh
@@ -37,8 +37,3 @@ mkdir -p src/main/resources/xslt/2015-1
 mkdir -p src/main/resources/xslt/2020-1
 cp $XSLT_PATH/2015-1/list-heading-and-pagebreak-references.xsl src/main/resources/xslt/2015-1
 cp $XSLT_PATH/2020-1/list-heading-and-pagebreak-references.xsl src/main/resources/xslt/2020-1
-
-
-mkdir -p src/main/resources/dtbook/compiled
-saxon11-xslt -s:src/main/resources/dtbook/sch/dtbook.mathml.nimas.sch -o:src/main/resources/dtbook/compiled/dtbook.mathml.nimas.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl
-saxon11-xslt -s:src/main/resources/dtbook/sch/dtbook.mathml.sch -o:src/main/resources/dtbook/compiled/dtbook.mathml.xsl -xsl:$SCHXSLT_PATH/src/main/resources/content/transpile.xsl

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.8.0-8</version>
+            <version>11.5</version>
         </dependency>
         <dependency>
             <groupId>org.w3c</groupId>

--- a/src/main/resources/xml/schema/2015-1/nordic2015-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2015-1/nordic2015-1.opf-and-html.sch
@@ -18,17 +18,15 @@
     <ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
     <ns prefix="epub" uri="http://www.idpf.org/2007/ops"/>
     <ns prefix="nordic" uri="http://www.mtm.se/epub/"/>
-    
-    <let name="ids" value="//xs:string(@id)"/>
 
     <pattern id="opf_and_html_nordic_1">
         <rule context="*[@id]">
             <let name="id" value="@id"/>
-            <assert test="count($ids[.=$id]) = 1">[nordic_opf_and_html_1] id attributes must be unique; <value-of select="@id"/> in <value-of select="replace(base-uri(.),'^.*/','')"/> also exists
+            <assert test="count(//*[@id=$id]) = 1">[nordic_opf_and_html_1] id attributes must be unique; <value-of select="@id"/> in <value-of select="replace(base-uri(.),'^.*/','')"/> also exists
                 in <value-of select="(//*[@id=$id] except .)/replace(base-uri(.),'^.*/','')"/></assert>
         </rule>
     </pattern>
-    
+
     <!-- Rule 13: All books must have frontmatter and bodymatter -->
     <pattern id="nordic_opf_and_html_13_a">
         <!-- see also nordic2015-1.sch for single-document version -->

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -41,15 +41,13 @@
     <ns prefix="epub" uri="http://www.idpf.org/2007/ops"/>
     <ns prefix="nordic" uri="http://www.mtm.se/epub/"/>
 
-    <let name="ids" value="//xs:string(@id)"/>
-
     <pattern id="opf_and_html_nordic_1">
         <title>Rule 1</title>
         <p></p>
         <rule context="*[@id]">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <let name="id" value="@id"/>
-            <assert test="count($ids[.=$id]) = 1">[nordic_opf_and_html_1] id attributes must be unique; <value-of select="@id"/> in <value-of select="replace(base-uri(.),'^.*/','')"/> also exists
+            <assert test="count(//*[@id=$id]) = 1">[nordic_opf_and_html_1] id attributes must be unique; <value-of select="@id"/> in <value-of select="replace(base-uri(.),'^.*/','')"/> also exists
                 in <value-of select="(//*[@id=$id] except .)/replace(base-uri(.),'^.*/','')"/></assert>
         </rule>
     </pattern>


### PR DESCRIPTION
Hi @josteinaj 

We found that some books that MTM ran crashed EPUBCheck. Some functions of Saxon were not available in version 9. New EPUBCheck 5.0.0 uses Saxon 11. And it required us to update all the schemas to version XSLT 3.0. 

XSLT 2.0 is no longer supported in Saxon 11.

Also needed to update Rule 1 of the `nordic2015-1.opf-and-html.sch` as it did not support the setting of global variables. I have tested and verified that the new solution finds ids that aren't unique.

Best regards
Daniel