### PR TITLE
Change ACE timeout and add type to validation

### DIFF
--- a/client/src/main/java/org/daisy/validator/EPUBFiles.java
+++ b/client/src/main/java/org/daisy/validator/EPUBFiles.java
@@ -383,11 +383,11 @@ public class EPUBFiles {
     }
 
     private void validateContent(File transformer, File validator) throws Exception {
-        validateFile(navFile, validator);
+        validateFile(navFile, validator, Guideline.XHTML);
         transformFile(navFile, transformer, Guideline.CONTENT_FILES, false);
 
         for (String filename : contentFiles) {
-            validateFile(filename, validator);
+            validateFile(filename, validator, Guideline.XHTML);
             transformFile(filename, transformer, Guideline.CONTENT_FILES, false);
         }
     }
@@ -412,9 +412,9 @@ public class EPUBFiles {
         }
     }
 
-    private void validateFile(String filename, File validator) throws Exception {
+    private void validateFile(String filename, File validator, String validatorType) throws Exception {
         if(completionService == null) return;
-        completionService.submit(new ValidateFile(epubDir, filename, validator));
+        completionService.submit(new ValidateFile(epubDir, filename, validator, validatorType));
         submittedWork++;
     }
 

--- a/client/src/main/java/org/daisy/validator/ValidateFile.java
+++ b/client/src/main/java/org/daisy/validator/ValidateFile.java
@@ -1,10 +1,9 @@
 package org.daisy.validator;
 
-import org.daisy.validator.report.Issue;
-import org.daisy.validator.schemas.Guideline;
 import com.thaiopensource.relaxng.jaxp.XMLSyntaxSchemaFactory;
 import com.thaiopensource.validation.Schema2;
 import com.thaiopensource.validation.Validator2;
+import org.daisy.validator.report.Issue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -16,24 +15,33 @@ public class ValidateFile implements Callable<List<Issue>> {
     private final Validator2 validator;
     private final File file;
     private final String filename;
+    private final String validationType;
 
-    public ValidateFile(File epubDir, String filename, File validatorFile) throws Exception {
+    public ValidateFile(File epubDir, String filename, File validatorFile, String validationType) throws Exception {
         XMLSyntaxSchemaFactory rngFactory = new XMLSyntaxSchemaFactory();
         Schema2 rngSchema = rngFactory.newSchema(validatorFile);
         validator = rngSchema.newValidator();
-        validator.setErrorHandler(new ValidationErrorHandler(filename));
+        validator.setErrorHandler(new ValidationErrorHandler(filename, validationType));
 
         this.file = new File(epubDir, filename);
         this.filename = filename;
+        this.validationType = validationType;
     }
 
     @Override
     public List<Issue> call() {
         List<Issue> errorList = new ArrayList<>();
+
         try {
             validator.validate(new StreamSource(file));
         } catch (Exception ioe) {
-            errorList.add(new Issue("", "[" +Guideline.XHTML + "] " + ioe.getMessage(), filename, Guideline.XHTML, Issue.ERROR_FATAL));
+            errorList.add(new Issue(
+                "",
+                "[" + validationType + "] " + ioe.getMessage(),
+                filename,
+                validationType,
+                Issue.ERROR_FATAL
+            ));
         }
 
         errorList.addAll(((ValidationErrorHandler) validator.getErrorHandler()).getErrorList());

--- a/client/src/main/java/org/daisy/validator/ValidationErrorHandler.java
+++ b/client/src/main/java/org/daisy/validator/ValidationErrorHandler.java
@@ -1,7 +1,6 @@
 package org.daisy.validator;
 
 import org.daisy.validator.report.Issue;
-import org.daisy.validator.schemas.Guideline;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -12,28 +11,30 @@ import java.util.List;
 public class ValidationErrorHandler implements ErrorHandler {
     private static final String PLACEMENT_FORMAT = "(Line: %05d Column: %05d) ";
     private final String filename;
+    private final String validationType;
     private final List<Issue> errorList = new ArrayList<>();
 
-    public ValidationErrorHandler(String filename) {
+    public ValidationErrorHandler(String filename, String validationType) {
         this.filename = filename;
+        this.validationType = validationType;
     }
 
     @Override
     public void warning(SAXParseException saxEx) throws SAXException {
         String lineIn = String.format(PLACEMENT_FORMAT, saxEx.getLineNumber(), saxEx.getColumnNumber());
-        errorList.add(new Issue("", "[" + Guideline.XHTML + "] " + lineIn + saxEx.getMessage(), filename, Guideline.XHTML, Issue.ERROR_WARN));
+        errorList.add(new Issue("", "[" + validationType + "] " + lineIn + saxEx.getMessage(), filename, validationType, Issue.ERROR_WARN));
     }
 
     @Override
     public void error(SAXParseException saxEx) throws SAXException {
         String lineIn = String.format(PLACEMENT_FORMAT, saxEx.getLineNumber(), saxEx.getColumnNumber());
-        errorList.add(new Issue("", "[" + Guideline.XHTML + "] " + lineIn + saxEx.getMessage(), filename, Guideline.XHTML, Issue.ERROR_ERROR));
+        errorList.add(new Issue("", "[" + validationType + "] " + lineIn + saxEx.getMessage(), filename, validationType, Issue.ERROR_ERROR));
     }
 
     @Override
     public void fatalError(SAXParseException saxEx) throws SAXException {
         String lineIn = String.format(PLACEMENT_FORMAT, saxEx.getLineNumber(), saxEx.getColumnNumber());
-        errorList.add(new Issue("", "[" + Guideline.XHTML + "] " + lineIn + saxEx.getMessage(), filename, Guideline.XHTML, Issue.ERROR_FATAL));
+        errorList.add(new Issue("", "[" + validationType + "] " + lineIn + saxEx.getMessage(), filename, validationType, Issue.ERROR_FATAL));
     }
 
     public List<Issue> getErrorList() {

--- a/client/src/main/java/org/daisy/validator/ace/ACEValidator.java
+++ b/client/src/main/java/org/daisy/validator/ace/ACEValidator.java
@@ -64,7 +64,7 @@ public class ACEValidator implements Callable<List<Issue>> {
              process = Runtime.getRuntime().exec(cmd);
         }
         int count = 0;
-        while(process.isAlive() && count < 10 * 60) {
+        while(process.isAlive() && count < 60 * 60) {
             Thread.sleep(1000);
             count++;
         }

--- a/client/src/test/java/TestValid.java
+++ b/client/src/test/java/TestValid.java
@@ -241,7 +241,8 @@ public class TestValid {
         ValidateFile vf = new ValidateFile(
                 new File("src/test/resources/valid2020"),
                 doc,
-                new File(epubFiles.getSchemaDir(), guideline.getSchema(Guideline.XHTML).getFilename())
+                new File(epubFiles.getSchemaDir(), guideline.getSchema(Guideline.XHTML).getFilename()),
+                Guideline.XHTML
         );
         Set<Issue> issues = new HashSet<>();
         issues.addAll(vf.call());


### PR DESCRIPTION
This PR will do two small changes. 

Changing the ACE runtime timeout to 60 minutes. We noticed that these runs can be longer for larger EPUBs.

Another thing was to send the type of document we validate in each step. This will make things more dynamic and help out when other documents needs validation.