### PR TITLE
Allow unordered metadata

### DIFF
--- a/client/src/main/java/org/daisy/validator/EPUBFiles.java
+++ b/client/src/main/java/org/daisy/validator/EPUBFiles.java
@@ -432,6 +432,9 @@ public class EPUBFiles {
     }
 
     public Guideline getGuideline() {
+        if (this.guideline == null) {
+            return new Guideline2015();
+        }
         return this.guideline;
     }
 

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -15,7 +15,7 @@
             <ref name="flow"/> <!-- em, strong, dfn, code, samp, kbd, span, abbr, math, a, img, br, q, sub, sup, bdo, p, hr, ol, ul, dl, pre, div, blockquote, section, table, address, aside, figure -->
         </define>
     </include>
-    
+
     <start>
         <a:documentation>The root element.</a:documentation>
         <ref name="html"/> <!-- html -->
@@ -534,9 +534,56 @@
     </define>
     
     <a:documentation>Document Head Metadata</a:documentation>
-    
+
+    <define name="head.charset">
+        <element name="meta">
+            <a:documentation>&lt;meta&gt; indicates metadata about the book. An empty
+                element that may appear repeatedly only in &lt;head&gt;.</a:documentation>
+            <a:documentation>&lt;meta&gt; is the container for the Dublin Core attributes.</a:documentation>
+            <attribute name="charset">
+                <value>UTF-8</value>
+            </attribute>
+        </element>
+    </define>
+    <define name="head.title">
+        <element name="title">
+            <a:documentation>&lt;title&gt; is required and defines the title of a document.</a:documentation>
+            <text/>
+        </element>
+    </define>
+    <define name="head.identifier">
+        <element name="meta">
+            <a:documentation>&lt;meta&gt; indicates metadata about the book. An empty
+                element that may appear repeatedly only in &lt;head&gt;.</a:documentation>
+            <a:documentation>&lt;meta&gt; is the container for the Dublin Core attributes.</a:documentation>
+            <attribute name="name">
+                <value>dc:identifier</value>
+            </attribute>
+            <attribute name="content">
+                <text/>
+            </attribute>
+        </element>
+    </define>
+    <define name="head.viewport">
+        <element name="meta">
+            <a:documentation>&lt;meta&gt; indicates metadata about the book. An empty
+                element that may appear repeatedly only in &lt;head&gt;.</a:documentation>
+            <a:documentation>&lt;meta&gt; is the container for the Dublin Core attributes.</a:documentation>
+            <attribute name="name">
+                <value>viewport</value>
+            </attribute>
+            <attribute name="content">
+                <value>width=device-width</value>
+            </attribute>
+        </element>
+    </define>
+
     <define name="headmisc">
         <choice>
+            <ref name="head.charset"/> <!-- head.charset -->
+            <ref name="head.identifier"/> <!-- head.identifier -->
+            <ref name="head.title"/> <!-- head.title -->
+            <ref name="head.viewport"/> <!-- head.viewport -->
             <ref name="meta"/> <!-- meta -->
             <ref name="link"/> <!-- link -->
             <ref name="style"/> <!-- style -->
@@ -558,43 +605,9 @@
             <!-- HTML content model: title & base? & (link | meta | noscript | script | style | template)* -->
             <!-- Strict content model: meta[charset] title meta[name=viewport] meta[name=nordic:guidelines] (meta | link)* link[rel=profile]? -->
             <ref name="attlist.head"/> <!-- @xml:lang, @lang, @dir -->
-            <element name="meta">
-                <a:documentation>&lt;meta&gt; indicates metadata about the book. An empty
-                    element that may appear repeatedly only in &lt;head&gt;.</a:documentation>
-                <a:documentation>&lt;meta&gt; is the container for the Dublin Core attributes.</a:documentation>
-                <attribute name="charset">
-                    <value>UTF-8</value>
-                </attribute>
-            </element>
-            <element name="title">
-                <a:documentation>&lt;title&gt; is required and defines the title of a document.</a:documentation>
-                <text/>
-            </element>
-            <element name="meta">
-                <a:documentation>&lt;meta&gt; indicates metadata about the book. An empty
-                    element that may appear repeatedly only in &lt;head&gt;.</a:documentation>
-                <a:documentation>&lt;meta&gt; is the container for the Dublin Core attributes.</a:documentation>
-                <attribute name="name">
-                    <value>dc:identifier</value>
-                </attribute>
-                <attribute name="content">
-                    <text/>
-                </attribute>
-            </element>
-            <element name="meta">
-                <a:documentation>&lt;meta&gt; indicates metadata about the book. An empty
-                    element that may appear repeatedly only in &lt;head&gt;.</a:documentation>
-                <a:documentation>&lt;meta&gt; is the container for the Dublin Core attributes.</a:documentation>
-                <attribute name="name">
-                    <value>viewport</value>
-                </attribute>
-                <attribute name="content">
-                    <value>width=device-width</value>
-                </attribute>
-            </element>
-            <zeroOrMore>
+            <oneOrMore>
                 <ref name="headmisc"/> <!-- meta, link, style, script -->
-            </zeroOrMore>
+            </oneOrMore>
         </element>
     </define>
     

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -14,10 +14,10 @@
         <title>Rule 1</title>
         <p>Only allow one charset, identifier, title and viewport</p>
         <rule context="html:head">
-            <assert test="count(html:meta[@charset='UTF-8'])=1">[nordic01] charset seems not to be in head exactly once</assert>
-            <assert test="count(html:meta[@name='dc:identifier'])=1">[nordic01] dc:identifier seems not to be in head exactly once</assert>
-            <assert test="count(html:title)=1">[nordic01] title seems not to be in head exactly once</assert>
-            <assert test="count(html:meta[@name='viewport'])=1">[nordic01] viewport seems not to be in head exactly once</assert>
+            <assert test="count(html:meta[@charset='UTF-8'])=1">[nordic01] charset must be in head exactly once</assert>
+            <assert test="count(html:meta[@name='dc:identifier'])=1">[nordic01] dc:identifier must be in head exactly once</assert>
+            <assert test="count(html:title)=1">[nordic01] title must be in head exactly once</assert>
+            <assert test="count(html:meta[@name='viewport'])=1">[nordic01] viewport must be in head exactly once</assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.sch
@@ -10,6 +10,17 @@
     <ns prefix="msv" uri="http://www.idpf.org/epub/vocab/structure/magazine/#"/>
     <ns prefix="prism" uri="http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#"/>
 
+    <pattern id="epub_nordic_1">
+        <title>Rule 1</title>
+        <p>Only allow one charset, identifier, title and viewport</p>
+        <rule context="html:head">
+            <assert test="count(html:meta[@charset='UTF-8'])=1">[nordic01] charset seems not to be in head exactly once</assert>
+            <assert test="count(html:meta[@name='dc:identifier'])=1">[nordic01] dc:identifier seems not to be in head exactly once</assert>
+            <assert test="count(html:title)=1">[nordic01] title seems not to be in head exactly once</assert>
+            <assert test="count(html:meta[@name='viewport'])=1">[nordic01] viewport seems not to be in head exactly once</assert>
+        </rule>
+    </pattern>
+
     <pattern id="epub_nordic_8">
         <title>Rule 8</title>
         <p>Only allow pagebreak w/page-front in frontmatter</p>


### PR DESCRIPTION
Hi @josteinaj 

Trying to solve https://github.com/nlbdev/nordic-epub3-dtbook-migrator/issues/536

This is a small change moving the uniqueness check of the metadata fields to Schematron.

I created a new rule called nordic_1. Maybe this number is already used, then we will change it, but validating unique fields in any order is not allowed in RelaxNG.

I did a quick check if I could add the Schematron rules as an extension of the RelaxNG rules. Seemed not to work so to be careful I created a new rule.