### PR TITLE
Fixing the time parsing issues, and adding the epubcheck error code information.

### DIFF
--- a/client/src/main/java/org/daisy/validator/Util.java
+++ b/client/src/main/java/org/daisy/validator/Util.java
@@ -101,8 +101,11 @@ public class Util {
         if (m.find()) {
             double val = 0;
 
-            if (m.group(2) != null) {
+            if (m.group(2) != null && m.group(3) != null) {
                 val += Long.parseLong(m.group(2).substring(0, m.group(2).length() - 1)) * 3600;
+            }
+            if (m.group(2) != null && m.group(3) == null) {
+                val += Long.parseLong(m.group(2).substring(0, m.group(2).length() - 1)) * 60;
             }
             if (m.group(3) != null) {
                 val += Long.parseLong(m.group(3).substring(0, m.group(3).length() - 1)) * 60;

--- a/client/src/main/java/org/daisy/validator/epubcheck/NordicReportImpl.java
+++ b/client/src/main/java/org/daisy/validator/epubcheck/NordicReportImpl.java
@@ -21,7 +21,9 @@ public class NordicReportImpl extends DefaultReportImpl {
     @Override
     public void message(Message message, EPUBLocation location, Object... args) {
         String fileName = PathUtil.removeWorkingDirectory(location.getPath());
-        String lineIn = "Line: " + location.getLine() + " Col: " + location.getColumn() + " ";
+        String lineIn = message.getSeverity().name();
+        lineIn += "(" + message.getID() + "): ";
+        lineIn += "Line: " + location.getLine() + " Col: " + location.getColumn() + " ";
 
         Severity severity = message.getSeverity();
         int errorCode = Issue.ERROR_WARN;

--- a/client/src/test/java/TestMediaOverlay.java
+++ b/client/src/test/java/TestMediaOverlay.java
@@ -1,5 +1,6 @@
 import org.daisy.validator.EPUBFiles;
 import org.daisy.validator.NordicValidator;
+import org.daisy.validator.report.Issue;
 import org.junit.Test;
 
 import java.io.File;
@@ -16,6 +17,11 @@ public class TestMediaOverlay {
         epubFiles.validateWithEpubCheck(tmpFile);
         epubFiles.validate();
         epubFiles.cleanUp();
+
+        for (Issue i : epubFiles.getErrorList()) {
+            System.out.println(i.getDescription() + " (" + i.getFilename() + ")");
+        }
+
         assertTrue(
             "Verify that a correct epub with media overlay don't generate any errors",
             epubFiles.getErrorList().size() == 0

--- a/client/src/test/java/TestTime.java
+++ b/client/src/test/java/TestTime.java
@@ -1,0 +1,20 @@
+import org.daisy.validator.Util;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTime {
+    @Test
+    public void testTime() {
+        Assert.assertEquals("Test longform" ,600100, Util.parseMilliSeconds("00:10:00.100"));
+        Assert.assertEquals("Test shortform" ,600100, Util.parseMilliSeconds("10:00.100"));
+        Assert.assertEquals("Test only seconds" ,1100, Util.parseMilliSeconds("01.100"));
+        Assert.assertEquals("Test second extension" ,100000, Util.parseMilliSeconds("100s"));
+        Assert.assertEquals("Test millisecond extension" ,100, Util.parseMilliSeconds("100ms"));
+        Assert.assertEquals("Test hour extension" ,3600000, Util.parseMilliSeconds("1h"));
+        Assert.assertEquals("Test minute extension" ,60000, Util.parseMilliSeconds("1min"));
+        Assert.assertEquals("Test second with decimals" ,100200, Util.parseMilliSeconds("100.2s"));
+        Assert.assertEquals("Test millisecond with decimals" ,100, Util.parseMilliSeconds("100.3ms"));
+        Assert.assertEquals("Test hours with decimals" ,5040000, Util.parseMilliSeconds("1.4h"));
+        Assert.assertEquals("Test minuties with decimals" ,66000, Util.parseMilliSeconds("1.1min"));
+    }
+}


### PR DESCRIPTION
Hi @josteinaj 

I realized that we didn't add the information on the severity and error ID from the EPUBCheck report, which might be good to have for searchability. So that is one of the small changes in this PR.

The other one is more severe. The original time parsing code was written in PHP, which is not greedy in their regular expressions. So in this PR, I added the test case we had in PHP and fixed the hour/minute parsing code to handle greedy regular expressions correctly.

Best regards
Daniel

