### PR TITLE
Fixing issue with cover image being in PNG format.

### DIFF
--- a/client/src/test/java/TestValid.java
+++ b/client/src/test/java/TestValid.java
@@ -6,7 +6,6 @@ import org.daisy.validator.ValidateFile;
 import org.daisy.validator.report.Issue;
 import org.daisy.validator.schemas.Guideline;
 import org.daisy.validator.schemas.Guideline2020;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedWriter;
@@ -22,7 +21,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.swing.tree.ExpandVetoException;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -45,6 +43,27 @@ public class TestValid {
             new File("src/main/resources/2020-1", guideline.getSchema(Guideline.OPF).getFilename()),
             Guideline.OPF,
             false
+        );
+        Set<Issue> issues = new HashSet<>();
+        issues.addAll(tf.call());
+
+        for(Issue i : issues) {
+            System.out.println(i.getDescription());
+        }
+
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    public void testCoverPNG_OPF() throws Exception {
+        Guideline guideline = new Guideline2020();
+
+        TransformFile tf = new TransformFile(
+                new File("src/test/resources/coverpng"),
+                "EPUB/package.opf",
+                new File("src/main/resources/2020-1", guideline.getSchema(Guideline.OPF).getFilename()),
+                Guideline.OPF,
+                false
         );
         Set<Issue> issues = new HashSet<>();
         issues.addAll(tf.call());

--- a/client/src/test/resources/coverpng/EPUB/package.opf
+++ b/client/src/test/resources/coverpng/EPUB/package.opf
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:epub="http://www.idpf.org/2007/ops"
+         prefix="nordic: http://www.mtm.se/epub/"
+         version="3.0"
+         xml:lang="en"
+         unique-identifier="pub-identifier">
+   <metadata>
+      <dc:title id="maintitle">How to test a cover png file</dc:title>
+      <meta refines="#maintitle" property="title-type">main</meta>
+      <dc:language>en</dc:language>
+      <dc:identifier id="pub-identifier">nordic_epub_2020_1_cover_png</dc:identifier>
+      <dc:source>urn:isbn:0000-0000</dc:source>
+      <dc:creator>Daniel Persson</dc:creator>
+      <dc:format>application/epub+zip</dc:format>
+      <dc:publisher>MTM</dc:publisher>
+      <dc:date>2022-05-31</dc:date>
+      <meta property="dcterms:modified">2023-04-24T08:07:42Z</meta>
+      <meta name="dcterms:modified" content="2023-04-24T08:07:42Z"/>
+      <meta property="nordic:guidelines">2020-1</meta>
+      <meta name="nordic:guidelines" content="2020-1"/>
+      <meta property="nordic:supplier">Textalk AB</meta>
+      <meta name="nordic:supplier" content="Textalk AB"/>
+      <meta property="schema:accessibilitySummary">This publication conforms to the Nordic Guidelines for the Production of Accessible EPUB 3, version 2020-1.</meta>
+      <meta property="schema:accessMode">textual</meta>
+      <meta property="schema:accessMode">visual</meta>
+      <meta property="schema:accessModeSufficient">textual,visual</meta>
+      <meta property="schema:accessModeSufficient">textual</meta>
+      <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+      <meta property="schema:accessibilityFeature">alternativeText</meta>
+      <meta property="schema:accessibilityHazard">none</meta>
+      <meta property="a11y:certifiedBy">MTM</meta>
+      <link rel="dcterms:conformsTo"
+            href="https://format.mtm.se/nordic_epub/2020-1"/>
+   </metadata>
+   <manifest>
+      <item href="css/epub.css" id="css" media-type="text/css"/>
+      <item href="nav.ncx" id="ncx" media-type="application/x-dtbncx+xml"/>
+      <item href="nav.xhtml"
+            id="nav"
+            media-type="application/xhtml+xml"
+            properties="nav"/>
+      <item href="images/cover.png"
+            id="coverimg"
+            media-type="image/png"
+            properties="cover-image"/>
+   </manifest>
+   <spine toc="ncx" page-progression-direction="ltr">
+      <itemref idref="cover" linear="no"/>
+   </spine>
+</package>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf.sch
@@ -239,7 +239,7 @@
     <pattern id="opf_nordic_15_a">
         <title>Rule 15a</title>
         <p></p>
-        <rule context="opf:item[substring-after(@href,'/') = 'cover.jpg']">
+        <rule context="opf:item[substring-after(@href,'/') = ('cover.jpg', 'cover.png')]">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <assert test="tokenize(@properties,'\s+') = 'cover-image'">[opf15a] The cover image must have a properties attribute containing the value 'cover-image': <value-of select="$context"/></assert>
         </rule>
@@ -250,7 +250,7 @@
         <p></p>
         <rule context="opf:item[tokenize(@properties,'\s+') = 'cover-image']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="substring-after(@href,'/') = 'cover.jpg'">[opf15b] The image with property value 'cover-image' must have the filename 'cover.jpg': <value-of select="$context"/></assert>
+            <assert test="substring-after(@href,'/') = ('cover.jpg', 'cover.png')">[opf15b] The image with property value 'cover-image' must have the filename 'cover.jpg' or 'cover.png': <value-of select="$context"/></assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Hi @josteinaj 

Trying to solve https://github.com/nlbdev/nordic-epub3-dtbook-migrator/issues/555

This one will make a minor change to check the OPF for the cover image. We will allow both cover.png and cover.jpg. The jpg case has already been covered since the 2015 format, so this will only somewhat loosen restrictions.

Best regards
Daniel