### PR TITLE
Fix endnotes issue

### DIFF
--- a/client/src/main/java/org/daisy/validator/EPUBFiles.java
+++ b/client/src/main/java/org/daisy/validator/EPUBFiles.java
@@ -608,4 +608,8 @@ public class EPUBFiles {
     public File getSchemaDir() {
         return schemaDir;
     }
+
+    public File getEpubDir() {
+        return epubDir;
+    }
 }

--- a/client/src/main/java/org/daisy/validator/EPUBFiles.java
+++ b/client/src/main/java/org/daisy/validator/EPUBFiles.java
@@ -612,4 +612,8 @@ public class EPUBFiles {
     public File getEpubDir() {
         return epubDir;
     }
+
+    public String getPackageFile() {
+        return this.packageOBF;
+    }
 }

--- a/client/src/test/java/TestValid.java
+++ b/client/src/test/java/TestValid.java
@@ -55,6 +55,71 @@ public class TestValid {
     }
 
     @Test
+    public void testOPFAndHTML() throws Exception {
+        File tmpFile = File.createTempFile("TestOPFAndHTML", ".xml");
+        FileOutputStream fos = new FileOutputStream(tmpFile);
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
+        bw.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        bw.newLine();
+        bw.write("<wrapper xmlns:html=\"http://www.w3.org/1999/xhtml\" xmlns:opf=\"http://www.idpf.org/2007/opf\">");
+        bw.newLine();
+        Util.appendXML(bw,
+            new FileInputStream(new File("src/test/resources/valid2020", "EPUB/package.opf"))
+        );
+        bw.newLine();
+
+        List<String> list = List.of(
+                "C00000-01-cover.xhtml",
+                "C00000-02-toc.xhtml",
+                "C00000-03-frontmatter.xhtml",
+                "C00000-04-chapter.xhtml",
+                "C00000-05-chapter.xhtml",
+                "C00000-06-chapter.xhtml",
+                "C00000-07-rearnotes.xhtml",
+                "C00000-08-chapter.xhtml",
+                "C00000-09-part.xhtml",
+                "C00000-10-chapter.xhtml",
+                "C00000-11-conclusion.xhtml",
+                "C00000-12-toc.xhtml",
+                "C00000-13-part.xhtml",
+                "C00000-14-chapter.xhtml",
+                "C00000-15-chapter.xhtml",
+                "C00000-16-part.xhtml",
+                "C00000-17-chapter.xhtml"
+        );
+
+        for (String contentFile : list) {
+            Util.appendXML(bw,
+                new FileInputStream(new File("src/test/resources/valid2020/EPUB", contentFile))
+            );
+            bw.newLine();
+            bw.flush();
+        }
+        bw.write("</wrapper>");
+        bw.flush();
+        bw.close();
+
+        Guideline guideline = new Guideline2020();
+
+        TransformFile tf = new TransformFile(
+                tmpFile.getParentFile(),
+                tmpFile.getName(),
+                new File("src/main/resources/2020-1", guideline.getSchema(Guideline.OPF_AND_HTML).getFilename()),
+                Guideline.OPF_AND_HTML,
+                false
+        );
+        Set<Issue> issues = new HashSet<>();
+        issues.addAll(tf.call());
+
+        for(Issue i : issues) {
+            System.out.println(i.getDescription());
+        }
+
+        assertEquals(0, issues.size());
+
+    }
+
+    @Test
     public void testCoverPNG_OPF() throws Exception {
         Guideline guideline = new Guideline2020();
 

--- a/client/src/test/resources/valid2020/EPUB/C00000-01-cover.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-01-cover.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:nordic="http://www.mtm.se/epub/" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#">
     <head>
         <meta charset="UTF-8"/>
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier"/>
         <meta name="viewport" content="width=device-width"/>
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-02-toc.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-02-toc.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:nordic="http://www.mtm.se/epub/" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#">
     <head>
         <meta charset="UTF-8"/>
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier"/>
         <meta name="viewport" content="width=device-width"/>
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-02-toc.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-02-toc.xhtml
@@ -10,7 +10,7 @@
     </head>
     <body>
         <section epub:type="frontmatter toc" id="toc_body" role="doc-toc">
-            <div role="doc-pagebreak" id="page_3" class="page-front" epub:type="pagebreak" title="iii"></div>
+            <div role="doc-pagebreak" id="page_front_3" class="page-front" epub:type="pagebreak" aria-label="iii"></div>
             <h1>Table of contents</h1>
             <ol>
                 <li>

--- a/client/src/test/resources/valid2020/EPUB/C00000-03-frontmatter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-03-frontmatter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-03-frontmatter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-03-frontmatter.xhtml
@@ -473,10 +473,10 @@
                         </tr>
                     </tbody>
                 </table>
-                <div id="page_4" class="page-front" epub:type="pagebreak" title="iv"></div>
-                <div epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page-vii" aria-label="vii"></div>
+                <div id="page_front_4" class="page-front" epub:type="pagebreak" aria-label="iv"></div>
+                <div epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page_front_7" aria-label="vii"></div>
                 <p>
-                    <span epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page-viii" aria-label="viii"></span>
+                    <span epub:type="pagebreak" role="doc-pagebreak" class="page-front" id="page_front_8" aria-label="viii"></span>
                 </p>
             </section>
             <section id="d910e617">
@@ -513,7 +513,7 @@
                 <p>
                     <span id="dtb125">Beatrice Christensen-Sköld</span>
                 </p>
-                <div id="page_front_5" class="page-front" epub:type="pagebreak" title="v"></div>
+                <div id="page_front_5" class="page-front" epub:type="pagebreak" aria-label="v"></div>
             </section>
         </section>
     </body>

--- a/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <meta name="a11y:certifiedBy" content="Certifying Organization"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
@@ -113,7 +113,6 @@
         <section id="d910e694" epub:type="bodymatter chapter">
             <div id="page_5" class="page-normal" epub:type="pagebreak" aria-label="5"></div>
             <div id="page_6" class="page-normal" epub:type="pagebreak" aria-label="6"></div>
-            <div id="page_7" class="page-normal" epub:type="pagebreak" aria-label="7"></div>
             <h1 id="d910e696">1. Research questions</h1>
             <pre><code>
                 public static void main(String[] args) {

--- a/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
@@ -111,8 +111,6 @@
     </head>
     <body>
         <section id="d910e694" epub:type="bodymatter chapter">
-            <div id="page_5" class="page-normal" epub:type="pagebreak" aria-label="5"></div>
-            <div id="page_6" class="page-normal" epub:type="pagebreak" aria-label="6"></div>
             <h1 id="d910e696">1. Research questions</h1>
             <pre><code>
                 public static void main(String[] args) {
@@ -134,13 +132,13 @@
             </p>
             <p><em>En fullständig lista över titlar utgivna i FOKK-serien finns på: <a href="http://www.kkrva.se/?page_id=715">http://www.kkrva.se/?page_id=715</a></em></p>
 
-            <aside id="dtb6" class="text-box">
+            <aside id="dtbt6" class="text-box">
                 <p epub:type="bridgehead">Header information</p>
                 <p>
-                    <span id="dtb8">Modifications have been done primarily to the footnotes, which in the original version used inline parentheses, and in this version use a noteref-endnote system.</span>
+                    <span id="dtbt7">Modifications have been done primarily to the footnotes, which in the original version used inline parentheses, and in this version use a noteref-endnote system.</span>
                 </p>
                 <p>
-                    <span id="dtb8">Modifications have been done primarily to the footnotes, which in the original version used inline parentheses, and in this version use a noteref-endnote system.</span>
+                    <span id="dtbt8">Modifications have been done primarily to the footnotes, which in the original version used inline parentheses, and in this version use a noteref-endnote system.</span>
                 </p>
             </aside>
 

--- a/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
@@ -125,7 +125,7 @@
                 <span id="dtb148">The researcher pieces together, in a manner of speaking, a mosaic from the fragments he manages to find. </span>
                 <span id="d910e810">
                     <span id="dtb149">These remains and traces may be many and varied; in the case of Haüy, they are mainly written sources </span>
-                    <a id="dtb150" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_1">1</a>
+                    <a id="dtb150" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_1">1</a>
                     <span id="dtb151">.</span>
                 </span>
             </p>
@@ -135,7 +135,7 @@
                 <span id="d910e831">
                     <span id="dtb154">When writing a biography, one should make use of material which directly or indirectly, in part or completely provides information about the life of one or several
                         people </span>
-                    <a id="dtb155" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_2">2</a>
+                    <a id="dtb155" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_2">2</a>
                     <span id="dtb156">. </span>
                 </span>
                 <span id="dtb157">This may or may not be written material. </span>
@@ -143,7 +143,7 @@
                     investigated is "third-person documentation". </span>
                 <span id="d910e850">
                     <span id="dtb159">The lack of first-hand sources naturally means that the validity of this type of documentation is questionable </span>
-                    <a id="dtb160" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_3">3</a>
+                    <a id="dtb160" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_3">3</a>
                     <span id="dtb161">. </span>
                 </span>
                 <span id="dtb162">However, some of the documentation I have used does in fact quote from first-hand sources or "first-person documents". </span>
@@ -185,7 +185,7 @@
                 <span id="dtb180">There was, for example, a box full of documents dating from the period 1807-1809, but only a few documents from the latter part of Haüy's stay in Russia. </span>
                 <span id="d910e939">
                     <span id="dtb181">Skrébitsky managed to smuggle the box out of Russia and donated it to the Valentin Haüy Museum in Paris where it is still kept </span>
-                    <a id="dtb182" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_4">4</a>
+                    <a id="dtb182" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_4">4</a>
                     <span id="dtb183">. </span>
                 </span>
                 <span id="dtb184">I have been able to ascertain that this information is correct, but have not had the opportunity to consult these documents personally. </span>

--- a/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-05-chapter.xhtml
@@ -149,7 +149,7 @@
                 <span id="dtb162">However, some of the documentation I have used does in fact quote from first-hand sources or "first-person documents". </span>
                 <span id="dtb163">To judge from the literature available on the subject, I am one of the very few (if not the only) researchers who have used Skrébitsky as a source.</span>
             </p>
-            <div id="page_6" class="page-normal" epub:type="pagebreak" title="6"></div>
+            <div id="page_6" class="page-normal" epub:type="pagebreak" aria-label="6"></div>
             <p>
                 <span id="dtb164">I did have access to a single first-hand source - the information I use to describe Haüy's pedagogical methods was, in part, gleaned from his own Essai sur l'Education
                     des Aveugles.</span>
@@ -202,7 +202,7 @@
                 <span id="dtb191">She is the only researcher to have made use of the minutes kept by the various revolutionary committees in Paris during the 1790s. </span>
                 <span id="dtb192">She does not, however, write about Haüy's years in Russia.</span>
             </p>
-            <div id="page_7" class="page-normal" epub:type="pagebreak" title="7"></div>
+            <div id="page_7" class="page-normal" epub:type="pagebreak" aria-label="7"></div>
             <p>
                 <span id="dtb193">To illustrate Haüy's influence on the development of education for the blind in other countries, I have chosen D.G. </span>
                 <span id="dtb194">Pritchard's Education and the Handicapped 1760-1960 (1963) as my main source since it is considered a standard work. </span>

--- a/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
@@ -117,12 +117,12 @@
                         creation of organised education for the handicapped. </span>
                     <span id="d910e1036">
                         <span id="dtb202">In 1760, the abbé l'épée founded the first school for the deaf, where his educational methods were based on the teaching of sign language </span>
-                        <a id="dtb203" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_5">5</a>
+                        <a id="dtb203" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_5">5</a>
                         <span id="dtb204">. </span>
                     </span>
                     <span id="d910e1048">
                         <span id="dtb205">Interest in education methods for the disabled began to develop seriously in the early years of the 19th century </span>
-                        <a id="dtb206" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_6">6</a>
+                        <a id="dtb206" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_6">6</a>
                         <span id="dtb207">.</span>
                     </span>
                 </p>
@@ -130,13 +130,13 @@
                     <span id="d910e1063">
                         <span id="dtb208">The debate on the social value of the handicapped and their learning capacity began with John Locke (1632-1704) and his essay "The Molyneux Problem," included in
                             "An Essay Concerning Human Understanding" </span>
-                        <a id="dtb209" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_7">7</a>
+                        <a id="dtb209" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_7">7</a>
                         <span id="dtb210">. </span>
                     </span>
                     <span id="dtb211">Locke received a letter from William Molyneux, an Irishman, dated 2nd March 1693, in which the following question was posed: "If a person who was born blind, and who
                         has learnt to distinguish by touch between a cube and a sphere regains vision after an operation, will he then be able to distinguish the cube from the sphere by sight alone?" </span>
                     <span id="d910e1078">
-                        <a id="dtb212" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_8">8</a>
+                        <a id="dtb212" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_8">8</a>
                         <span id="dtb213">.</span>
                     </span>
                 </p>
@@ -148,7 +148,7 @@
                     <span id="dtb216">On the one hand, Diderot exposed a fraud which had taken place in the drawing-room of the scientist S.A. </span>
                     <span id="d910e1099">
                         <span id="dtb217">Réaumur , while on the other he made a number of observations which were a radical criticism of the conventional ideas of the time </span>
-                        <a id="dtb218" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_9">9</a>
+                        <a id="dtb218" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_9">9</a>
                         <span id="dtb219">. </span>
                     </span>
                     <span id="dtb220">The fraud in question consisted of a performance by a girl who claimed to be blind in Réaumur's drawing-room during which she played, sang and answered a series of
@@ -158,7 +158,7 @@
                     <span id="d910e1121">
                         <span id="dtb223">In the second half of his letter, Diderot has Saunderson express, in an imaginary dialogue, his own atheistic philosophy of life, for which Diderot paid with a
                             brief sojourn in prison </span>
-                        <a id="dtb224" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_10">10</a>
+                        <a id="dtb224" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_10">10</a>
                         <span id="dtb225">.</span>
                     </span>
                 </p>
@@ -166,12 +166,12 @@
                     <span id="dtb226">Diderot's letter made the bourgeoisie of the time aware that the blind could in fact be educated. </span>
                     <span id="d910e1139">
                         <span id="dtb227">He went on to found a philanthrophic society in 1780 - the Société Philanthropique </span>
-                        <a id="dtb228" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_11">11</a>
+                        <a id="dtb228" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_11">11</a>
                         <span id="dtb229">, which opened up homes for the blind where they were taught handicrafts. </span>
                     </span>
                     <span id="d910e1151">
                         <span id="dtb230">These "homes for the blind" -"Maisons des Enfans-Aveugles"- took in blind persons between the ages of 20 and 25 </span>
-                        <a id="dtb231" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_12">12</a>
+                        <a id="dtb231" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_12">12</a>
                         <span id="dtb232">.</span>
                     </span>
                 </p>
@@ -182,7 +182,7 @@
                 <p>
                     <span id="d910e1176">
                         <span id="dtb234">Diderot himself had a blind pupil, Mélanie de Salignac (1741-1763), who was his friend Sophie Volland's niece </span>
-                        <a id="dtb235" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_13">13</a>
+                        <a id="dtb235" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_13">13</a>
                         <span id="dtb236">. </span>
                     </span>
                     <span id="dtb237">He wrote about her in Addition de Lettre sur les Aveugles. </span>
@@ -198,7 +198,7 @@
                     <span id="d910e1215">
                         <span id="dtb243">Haüy's elder brother, the abbé René Just Haüy (1743-1822), was the pioneer of crystallography (the science of the structure, forms and property of crystals) and
                             played an important role in the introduction of the metric system </span>
-                        <a id="dtb244" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_14">14</a>
+                        <a id="dtb244" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_14">14</a>
                         <span id="dtb245">.</span>
                     </span>
                 </p>
@@ -211,7 +211,7 @@
                     <span id="d910e1246">
                         <span id="dtb251">He later became a member of the Bureau Académique des écritures, founded by Louis XVI, probably because he had invented a method of deciphering secret codes and
                             military code systems </span>
-                        <a id="dtb252" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_15">15</a>
+                        <a id="dtb252" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_15">15</a>
                         <span id="dtb253">. </span>
                     </span>
                     <span id="dtb254">In 1771, the French police began to take an interest in deciphering codes, and during the following ten years, Valentin Haüy worked for the secret police, where his
@@ -222,12 +222,12 @@
                     <span id="dtb256">Haüy was also interested in the education of the deaf. </span>
                     <span id="d910e1270">
                         <span id="dtb257">He is said to have been actively involved in the teaching of deaf pupils and to have worked from time to time with the abbé l'épée </span>
-                        <a id="dtb258" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_16">16</a>
+                        <a id="dtb258" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_16">16</a>
                         <span id="dtb259">. </span>
                     </span>
                     <span id="d910e1282">
                         <span id="dtb260">We can assume that his interest in the handicapped had already been aroused in 1771 when he visited one of the public performances given by the abbé's deaf pupils </span>
-                        <a id="dtb261" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_17">17</a>
+                        <a id="dtb261" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_17">17</a>
                         <span id="dtb262">.</span>
                     </span>
                 </p>
@@ -237,7 +237,7 @@
                 <p>
                     <span id="d910e1306">
                         <span id="dtb264">In a letter to his son, Haüy tells how during the annual market in St Ovid's Square in Paris, he saw blind musicians from the Quinze-Vingt asylum perform </span>
-                        <a id="dtb265" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_18">18</a>
+                        <a id="dtb265" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_18">18</a>
                         <span id="dtb266">. </span>
                     </span>
                     <span id="dtb267">He was sitting at a café when he saw some very strange creatures fitted with huge paper spectacles and pointed hats with donkey's ears affixed to them. </span>
@@ -269,7 +269,7 @@
                 </blockquote>
                 <p>
                     <span id="d910e1379">
-                        <a id="dtb280" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_19">19</a>
+                        <a id="dtb280" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_19">19</a>
                         <span id="dtb281">.</span>
                     </span>
                 </p>
@@ -283,7 +283,7 @@
                         decided to contact her. </span>
                     <span id="d910e1409">
                         <span id="dtb286">Maria Theresia von Paradis was born in Vienna and became blind at about 4 years of age </span>
-                        <a id="dtb287" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_20">20</a>
+                        <a id="dtb287" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_20">20</a>
                         <span id="dtb288">. </span>
                     </span>
                     <span id="dtb289">Jantsch suggests that the girl's blindness had hysterical origins. </span>
@@ -299,7 +299,7 @@
                         smaller buttons for smaller cities or towns. </span>
                     <span id="d910e1446">
                         <span id="dtb296">Von Paradis had raised texts printed; a special printing press was made for her by Wolfgang Ritter von Kempelen </span>
-                        <a id="dtb297" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_21">21</a>
+                        <a id="dtb297" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_21">21</a>
                         <span id="dtb298">. </span>
                     </span>
                 </p>
@@ -312,19 +312,19 @@
                     <span id="d910e1473">
                         <span id="dtb302">Haüy's meeting with Maria Theresia von Paradis gave him the inspiration and encouragement he so desperately needed at that time to develop an educational
                             programme for blind children </span>
-                        <a id="dtb303" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_22">22</a>
+                        <a id="dtb303" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_22">22</a>
                         <span id="dtb304">. </span>
                     </span>
                     <span id="d910e1485">
                         <span id="dtb305">He presented his plan, "Plan de l'Education à l'Usage des Aveugles," to the Philanthropic Society, which at that time sponsored twelve children from poor families </span>
-                        <a id="dtb306" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_23">23</a>
+                        <a id="dtb306" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_23">23</a>
                         <span id="dtb307">. </span>
                     </span>
                 </p>
                 <p>
                     <span id="d910e1501">
                         <span id="dtb308">In his Essai sur l'Education des Enfans-Aveugles </span>
-                        <a id="dtb309" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_24">24</a>
+                        <a id="dtb309" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_24">24</a>
                         <span id="dtb310">, Haüy repeatedly mentions that several of the tools he recommended for the teaching of blind children had been used by Maria Theresia von Paradis. </span>
                     </span>
                 </p>
@@ -335,7 +335,7 @@
                 <p>
                     <span id="d910e1529">
                         <span id="dtb312">Haüy was convinced that the blind deserved a better life than begging and performing in market places </span>
-                        <a id="dtb313" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_25">25</a>
+                        <a id="dtb313" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_25">25</a>
                         <span id="dtb314">. </span>
                     </span>
                     <span id="dtb315">They ought to enjoy the same right to education and work as the sighted. </span>
@@ -345,20 +345,20 @@
                 <p>
                     <span id="d910e1553">
                         <span id="dtb318">Haüy first met Lesueur, standing begging at the entrance to the church of Saint-Germain-des Prés </span>
-                        <a id="dtb319" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_26">26</a>
+                        <a id="dtb319" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_26">26</a>
                         <span id="dtb320">. </span>
                     </span>
                     <span id="d910e1565">
                         <span id="dtb321">Lesueur was a professional beggar who supported himself, his parents and four siblings with the money he was given by churchgoers (since the Middle Ages, the
                             Catholic Church had allowed the blind to beg outside churches) </span>
-                        <a id="dtb322" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_27">27</a>
+                        <a id="dtb322" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_27">27</a>
                         <span id="dtb323">.</span>
                     </span>
                 </p>
                 <p>
                     <span id="d910e1580">
                         <span id="dtb324">The story goes on to tell how Haüy, when he gave Lesueur some money, was told, "You thought you gave me a measly sou when in fact it was an écu " </span>
-                        <a id="dtb325" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_28">28</a>
+                        <a id="dtb325" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_28">28</a>
                         <span id="dtb326">. </span>
                     </span>
                     <span id="dtb327">From this incident Haüy immediately drew conclusions regarding the fine sense of touch the blind possess. </span>
@@ -375,14 +375,14 @@
                     <span id="dtb336">Haüy had started teaching Lesueur on 31st May 1784. </span>
                     <span id="d910e1626">
                         <span id="dtb337">By September of the same year, he was able to announce his progress in an article in the Journal de Paris </span>
-                        <a id="dtb338" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_29">29</a>
+                        <a id="dtb338" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_29">29</a>
                         <span id="dtb339">. </span>
                     </span>
                     <span id="dtb340">On November 18th, both teacher and pupil appeared before the Académie de l'écriture. </span>
                     <span id="dtb341">It was common practice at that time for pupils to appear before the Academy and the Court, and not just "handicapped prodigies". </span>
                     <span id="d910e1645">
                         <span id="dtb342">The Academy apparently fulfilled some kind of educational inspecting and authorising function </span>
-                        <a id="dtb343" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_30">30</a>
+                        <a id="dtb343" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_30">30</a>
                         <span id="dtb344">.</span>
                     </span>
                 </p>
@@ -391,14 +391,14 @@
                     <span id="dtb346">This made Haüy's name as a teacher of the blind. </span>
                     <span id="d910e1667">
                         <span id="dtb347">The Academy decided to recommend his methods of teaching the blind </span>
-                        <a id="dtb348" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_31">31</a>
+                        <a id="dtb348" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_31">31</a>
                         <span id="dtb349">. </span>
                     </span>
                     <span id="dtb350">Thanks to Haüy's brother René-Just, the French Academy of Science became interested in his teaching methods. </span>
                     <span id="dtb351">Four members of the Academy studied Haüy's methods and expressed their approval. </span>
                     <span id="d910e1686">
                         <span id="dtb352">Their report was registered by the Academy on 16th February 1785 </span>
-                        <a id="dtb353" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_32">32</a>
+                        <a id="dtb353" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_32">32</a>
                         <span id="dtb354">.</span>
                     </span>
                 </p>
@@ -406,7 +406,7 @@
                     <span id="dtb355">In January 1785, Haüy became a member of the Société Philanthropique which also entrusted him with the teaching of their twelve blind protégés. </span>
                     <span id="d910e1704">
                         <span id="dtb356">These were all young adults aged between 20 and 30 </span>
-                        <a id="dtb357" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_33">33</a>
+                        <a id="dtb357" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_33">33</a>
                         <span id="dtb358">. </span>
                     </span>
                     <span id="dtb359">Haüy could now rent a house in the Rue Coquillère where he taught his pupils. </span>
@@ -414,7 +414,7 @@
                         for the blind, and so l'Institution des Jeunes Aveugles (the Institute for Blind Children ) was born. </span>
                     <span id="d910e1722">
                         <span id="dtb361">The pupils who now arrived at the institute were young children </span>
-                        <a id="dtb362" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_34">34</a>
+                        <a id="dtb362" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_34">34</a>
                         <span id="dtb363">.</span>
                     </span>
                 </p>
@@ -430,7 +430,7 @@
                     <span id="dtb369">Haüy did, however, accept sighted children from well-to-do families who paid for their children's education. </span>
                     <span id="d910e1761">
                         <span id="dtb370">Haüy believed that sighted and blind children should be educated together without restriction </span>
-                        <a id="dtb371" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_35">35</a>
+                        <a id="dtb371" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_35">35</a>
                         <span id="dtb372">.</span>
                     </span>
                 </p>
@@ -504,12 +504,12 @@
                         illustrate the concepts of countries, lakes, rivers, mountains, etc. </span>
                     <span id="d910e1914">
                         <span id="dtb402">He goes on to describe the method of producing maps developed by von Paradis and Weissenburg </span>
-                        <a id="dtb403" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_36">36</a>
+                        <a id="dtb403" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_36">36</a>
                         <span id="dtb404">. </span>
                     </span>
                     <span id="d910e1926">
                         <span id="dtb405">As for music and the possibility of a blind person's earning his living as a musician, Haüy points to von Paradis's success and her system of raised musical notes </span>
-                        <a id="dtb406" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_37">37</a>
+                        <a id="dtb406" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_37">37</a>
                         <span id="dtb407">.</span>
                     </span>
                 </p>
@@ -521,7 +521,7 @@
                 <p>
                     <span id="d910e1950">
                         <span id="dtb410">Haüy's invention, a method of producing raised letters on paper with the types he had cast, was completely new </span>
-                        <a id="dtb411" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_38">38</a>
+                        <a id="dtb411" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_38">38</a>
                         <span id="dtb412">. </span>
                     </span>
                     <span id="dtb413">He now saw as his principle task to attempt to produce as many copies of books for the blind as possible. </span>
@@ -529,7 +529,7 @@
                     <span id="dtb415">In time he designed and had made a printing press which could produce raised print and to which he added a device for dyeing the raised letters black. </span>
                     <span id="d910e1971">
                         <span id="dtb416">The first two books printed by Haüy for his blind pupils were produced in this way </span>
-                        <a id="dtb417" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_39">39</a>
+                        <a id="dtb417" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_39">39</a>
                         <span id="dtb418">. </span>
                     </span>
                     <span id="dtb419">One was his own treatise on education for the blind: Essai sur l'Education des Enfans-Aveugles (1786); the other a historical review of the institute's first five
@@ -544,7 +544,7 @@
                     <span id="dtb424">This would produce raised letters on the other side of the paper, letters which the writer himself would be able to read by touch. </span>
                     <span id="d910e2006">
                         <span id="dtb425">Unfortunately, his apparatus was not of much use to those who had never seen letters </span>
-                        <a id="dtb426" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_40">40</a>
+                        <a id="dtb426" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_40">40</a>
                         <span id="dtb427">.</span>
                     </span>
                 </p>
@@ -555,7 +555,7 @@
                     <span id="dtb431">They produced raised print but also printed in ink. </span>
                     <span id="d910e2034">
                         <span id="dtb432">Towards the end of his essay on the education of the blind, </span>
-                        <a id="dtb433" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_41">41</a>
+                        <a id="dtb433" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_41">41</a>
                         <span id="dtb434"> there are ten or so examples of the blind children's printing activities (invitation cards, announcements, invoices, prospectuses, etc.). </span>
                     </span>
                     <span id="dtb435">Although Haüy had raised scores made, he did not at first consider music to be anything more than an entertainment for the blind.</span>
@@ -564,14 +564,14 @@
                 <p>
                     <span id="d910e2056">
                         <span id="dtb436">He changed his opinion later when he discovered that the blind could learn to play the organ and thus could be employed as church organists </span>
-                        <a id="dtb437" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_42">42</a>
+                        <a id="dtb437" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_42">42</a>
                         <span id="dtb438">.</span>
                     </span>
                 </p>
                 <p>
                     <span id="d910e2071">
                         <span id="dtb439">The aim behind Haüy's teaching methods was to enable his blind pupils to communicate satisfactorily with the sighted </span>
-                        <a id="dtb440" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_43">43</a>
+                        <a id="dtb440" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_43">43</a>
                         <span id="dtb441">. </span>
                     </span>
                     <span id="dtb442">He therefore rejected all writing systems for the blind which did not use the Roman alphabet. </span>
@@ -581,14 +581,14 @@
                     <span id="d910e2092">
                         <span id="dtb444">At first, boys and girls were taught together in mixed classes, but some years later, after Haüy had been severely criticised for the co-educational organisation
                             of his school, the sexes were segregated </span>
-                        <a id="dtb445" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_44">44</a>
+                        <a id="dtb445" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_44">44</a>
                         <span id="dtb446">.</span>
                     </span>
                 </p>
                 <p>
                     <span id="d910e2107">
                         <span id="dtb447">Haüy's successor at the institute, Guillé, was himself severely criticised for his harsh methods of punishment </span>
-                        <a id="dtb448" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_45">45</a>
+                        <a id="dtb448" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_45">45</a>
                         <span id="dtb449">. </span>
                     </span>
                     <span id="dtb450">In the accusations made against Guillé, his severity was compared with Haüy's mild methods and his concern for his pupils. </span>
@@ -603,7 +603,7 @@
                     <span id="dtb455">Education at the institute, however, continued along the same lines as it had done under the monarchy. </span>
                     <span id="d910e2146">
                         <span id="dtb456">The various revolutionary governments for their part believed that all forms of education should be free of charge and controlled by the State </span>
-                        <a id="dtb457" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_46">46</a>
+                        <a id="dtb457" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_46">46</a>
                         <span id="dtb458">. </span>
                     </span>
                 </p>
@@ -612,7 +612,7 @@
                     <span id="dtb460">The need to reduce financial costs was responsible for the fusion of the Institute for the Blind and L'épée's Institute for the Deaf. </span>
                     <span id="d910e2167">
                         <span id="dtb461">The resulting institute was moved to a monastery </span>
-                        <a id="dtb462" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_47">47</a>
+                        <a id="dtb462" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_47">47</a>
                         <span id="dtb463">. </span>
                     </span>
                     <span id="dtb464">This fusion, however, was unsuccessful, and in 1794 the National Convention decided to separate the two schools once more. </span>
@@ -626,14 +626,14 @@
                     <span id="d910e2201">
                         <span id="dtb470">After the break-up, the Institute for the Blind moved to a former convent at 34, Rue Denis, where it was renamed l'Institut National des Aveugles Travailleurs ,
                             that is The National Institute for Blind Craftsmen </span>
-                        <a id="dtb471" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_48">48</a>
+                        <a id="dtb471" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_48">48</a>
                         <span id="dtb472">. </span>
                     </span>
                     <span id="dtb473">Coinciding with the move, the institute was reorganised and the pupils now had to contribute to the upkeep of the new, revolutionary France (28th July, 1795). </span>
                     <span id="dtb474">The blind pupils' first task was to make 86 purses. </span>
                     <span id="d910e2219">
                         <span id="dtb475">At this point, the revolutionary committees began to debate whether institutes for the disabled should be classed as schools or asylums </span>
-                        <a id="dtb476" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_49">49</a>
+                        <a id="dtb476" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_49">49</a>
                         <span id="dtb477">. </span>
                     </span>
                 </p>
@@ -641,10 +641,10 @@
                     <span id="dtb478">Haüy initially sided with the Revolution. </span>
                     <span id="d910e2237">
                         <span id="dtb479">He was, as we said, an active member of one of the revolutionary committees </span>
-                        <a id="dtb480" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_50">50</a>
+                        <a id="dtb480" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_50">50</a>
                         <span id="dtb481">, and on 8th of June 1794, "the Day of Pure Reason", he did not hesitate to have his blind musicians appear on a mobile platform from which he, in revolutionary
                             language, urged them to follow Robespierre, who was dressed as the high priest of Pure Reason </span>
-                        <a id="dtb482" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_51">51</a>
+                        <a id="dtb482" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_51">51</a>
                         <span id="dtb483">. </span>
                     </span>
                 </p>
@@ -654,13 +654,13 @@
                     <span id="dtb485">Haüy's ability to adapt to the different régimes would later go against him, however. </span>
                     <span id="d910e2268">
                         <span id="dtb486">During the Directorate, Haüy founded what was called a theophilanthropic cult with two other revolutionaries, La Revellère-Lepeaux and Chemin-Dupontè </span>
-                        <a id="dtb487" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_52">52</a>
+                        <a id="dtb487" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_52">52</a>
                         <span id="dtb488">. </span>
                     </span>
                     <span id="dtb489">This could be described as a development of the cult of pure reason in which the magistrate assumed the role of the priest. </span>
                     <span id="d910e2283">
                         <span id="dtb490">The theophilanthropists substituted the head of the family for the priest; their philosophy was a mixture of theodicy and belief in the good individual </span>
-                        <a id="dtb491" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_53">53</a>
+                        <a id="dtb491" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_53">53</a>
                         <span id="dtb492">. </span>
                     </span>
                     <span id="dtb493">Haüy's successor as director of the institute (Guillé) was a strict Catholic who was horrified by Haüy's philosophical ideas. </span>
@@ -673,13 +673,13 @@
                     <span id="dtb498">Haüy lodged a complaint with the consular government but this was rejected outright; no money was forthcoming. </span>
                     <span id="d910e2320">
                         <span id="dtb499">His activities during the Reign of Terror and the Directorate spoke against him </span>
-                        <a id="dtb500" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_54">54</a>
+                        <a id="dtb500" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_54">54</a>
                         <span id="dtb501">. </span>
                     </span>
                     <span id="d910e2333">
                         <span id="dtb502">On 14th March 1801, Napoleon Bonaparte, now First Consul, decided that the Institute for Blind Craftsmen should be integrated into the Quinze-Vingt Hospital, an
                             asylum for elderly blind people which had existed since the end of the 13th Century </span>
-                        <a id="dtb503" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_55">55</a>
+                        <a id="dtb503" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_55">55</a>
                         <span id="dtb504">. </span>
                     </span>
                     <span id="dtb505">Napoleon furthermore forbade the theophilanthropists to practise their cult. </span>
@@ -688,7 +688,7 @@
                         the Second Consulate). </span>
                     <span id="d910e2354">
                         <span id="dtb508">The minister answered that the State was responsible for the education of the blind; Haüy's role was simply to carry out the State's orders </span>
-                        <a id="dtb509" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_56">56</a>
+                        <a id="dtb509" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_56">56</a>
                         <span id="dtb510">. </span>
                     </span>
                     <span id="dtb511">The answer to the last of the letters (dated 12th February 1802) was Haüy's dismissal, although he was granted a pension of 2000 livres a year. </span>
@@ -701,7 +701,7 @@
                     <span id="d910e2384">
                         <span id="dtb514">He was now assured of an annual income of 2000 livres, so it was not long before he founded a private institute for the blind which he called the Musée des
                             Aveugles </span>
-                        <a id="dtb515" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_57">57</a>
+                        <a id="dtb515" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_57">57</a>
                         <span id="dtb516">. </span>
                     </span>
                     <span id="dtb517">He planned that the new institute should complement the National Institute for the Blind. </span>
@@ -717,7 +717,7 @@
                     <span id="dtb524">Skrébitsky says that Haüy was very heavily in debt when he eventually arrived in St Petersburg. </span>
                     <span id="d910e2424">
                         <span id="dtb525">A Maltese banker, amongst others, demanded payment which was deducted from his salary in Russia </span>
-                        <a id="dtb526" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_58">58</a>
+                        <a id="dtb526" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_58">58</a>
                         <span id="dtb527">.</span>
                     </span>
                 </p>
@@ -731,7 +731,7 @@
                         <span id="dtb530">Word of Valentin Haüy's success soon spread throughout Europe. </span>
                         <span id="d910e2462">
                             <span id="dtb531">Several of the enlightened rulers were interested in acquiring his services </span>
-                            <a id="dtb532" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_59">59</a>
+                            <a id="dtb532" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_59">59</a>
                             <span id="dtb533">. </span>
                         </span>
                         <span id="dtb534">Teaching of the blind had started both in Vienna and in Berlin and Haüy exported his typographic cases and material for use in object lessons to institutes for
@@ -740,9 +740,9 @@
                             Russia. </span>
                         <span id="d910e2480">
                             <span id="dtb536">The tsar, himself educated in the spirit of Enlightenment </span>
-                            <a id="dtb537" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_60">60</a>
+                            <a id="dtb537" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_60">60</a>
                             <span id="dtb538">, invited Haüy to come to Russia for the purpose of founding an institute for the blind </span>
-                            <a id="dtb539" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_61">61</a>
+                            <a id="dtb539" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_61">61</a>
                             <span id="dtb540">.</span>
                         </span>
                     </p>
@@ -769,7 +769,7 @@
                         <span id="d910e2544">
                             <span id="dtb552">Haüy, whose idea the project was, agreed to teach his methods faithfully to the person appointed by His Imperial Highness Alexander I to direct the St
                                 Petersburg Institute for the Blind </span>
-                            <a id="dtb553" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_62">62</a>
+                            <a id="dtb553" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_62">62</a>
                             <span id="dtb554">.</span>
                         </span>
                     </p>
@@ -813,26 +813,26 @@
                         <span id="dtb573">He had already received a request from the king of Prussia who wondered if Haüy would be interested in founding a school for the blind in Berlin. </span>
                         <span id="d910e2650">
                             <span id="dtb574">In Prussia initiatives had already been taken in the 1780s to gain State control of all educational activities </span>
-                            <a id="dtb575" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_63">63</a>
+                            <a id="dtb575" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_63">63</a>
                             <span id="dtb576">. </span>
                         </span>
                         <span id="dtb577">King Frederick William III introduced Haüy to professor Johan August Zeune (1778-1853), who was already engaged in teaching blind children. </span>
                         <span id="d910e2665">
                             <span id="dtb578">Haüy and Zeune together designed a curriculum for an institute for the blind in Berlin </span>
-                            <a id="dtb579" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_64">64</a>
+                            <a id="dtb579" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_64">64</a>
                             <span id="dtb580">. </span>
                         </span>
                         <span id="dtb581">Professor Zeune later became the director of the institute. </span>
                         <span id="d910e2681">
                             <span id="dtb582">In Berlin as in Paris attempts were made to fulfil an important pedagogical objective: the combination of a theoretical-humanistic education and practical
                                 activities </span>
-                            <a id="dtb583" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_65">65</a>
+                            <a id="dtb583" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_65">65</a>
                             <span id="dtb584">. </span>
                         </span>
                         <span id="d910e2693">
                             <span id="dtb585">The battle of Jena and Auerstedt delayed Haüy's departure for St Petersburg, but in spite of this delay, he took time during the journey from Berlin to make a
                                 detour to Mitau in Kurland (today Jelgava in Latvia), where the Bourbon pretender to the French throne, Louis XVIII, was living in exile </span>
-                            <a id="dtb586" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_66">66</a>
+                            <a id="dtb586" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_66">66</a>
                             <span id="dtb587">. </span>
                         </span>
                         <span id="dtb588">Haüy paid his respects to Louis XVIII, who assured him of his support when he returned to France.</span>
@@ -847,7 +847,7 @@
                             well-versed in academic subjects such as history and geography. </span>
                         <span id="d910e2726">
                             <span id="dtb592">Haüy also wished to demonstrate an invention of his, the "advanced telegraph" </span>
-                            <a id="dtb593" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_67">67</a>
+                            <a id="dtb593" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_67">67</a>
                             <span id="dtb594">. </span>
                         </span>
                         <span id="dtb595">Skrébitsky states that he was unable to find any sources indicating that the Tsar actually received Haüy.</span>
@@ -859,7 +859,7 @@
                             <span id="dtb598">Skrébitsky says that he has found the letter in question and that it had a note in the margin (with a signature which probably belonged to the Minister of the
                                 General Education, Count Zawadowsky) which read, "The Tsar ordered this bill to be paid, premises to be found for the institute and a director who would learn Haüy's
                                 teaching methods to be selected and appointed to the institute" </span>
-                            <a id="dtb599" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_68">68</a>
+                            <a id="dtb599" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_68">68</a>
                             <span id="dtb600">. </span>
                         </span>
                         <span id="dtb601">Eight days after Haüy presented his petition, the money he had been promised was paid.</span>
@@ -887,7 +887,7 @@
                     </blockquote>
                     <p>
                         <span id="d910e2815">
-                            <a id="dtb614" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_69">69</a>
+                            <a id="dtb614" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_69">69</a>
                             <span id="dtb615">.</span>
                         </span>
                     </p>
@@ -915,7 +915,7 @@
                         <span id="d910e2877">
                             <span id="dtb631">In his letter Haüy also mentioned his two assistants and praised Bouchoueff, but complained about the latter's " weak health, which permitted him to dedicate
                                 only half-days to studies which required at least a year of continuous dedication" </span>
-                            <a id="dtb632" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_70">70</a>
+                            <a id="dtb632" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_70">70</a>
                             <span id="dtb633">.</span>
                         </span>
                     </p>
@@ -923,7 +923,7 @@
                         <span id="dtb634">Was it for tactical reasons that Haüy praised Bouchoueff, who obviously did not make any major contribution to the work of the institute? </span>
                         <span id="d910e2895">
                             <span id="dtb635">Haüy did not receive much help from his two assistants either, since they drank and turned out to be generally inept </span>
-                            <a id="dtb636" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_71">71</a>
+                            <a id="dtb636" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_71">71</a>
                             <span id="dtb637">. </span>
                         </span>
                         <span id="dtb638">Two other persons, however, announced their interest in teaching at Haüy's school. </span>
@@ -1002,7 +1002,7 @@
                     </blockquote>
                     <p>
                         <span id="d910e3066">
-                            <a id="dtb676" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_72">72</a>
+                            <a id="dtb676" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_72">72</a>
                             <span id="dtb677">.</span>
                         </span>
                     </p>
@@ -1120,7 +1120,7 @@
                     </blockquote>
                     <p>
                         <span id="d910e3314">
-                            <a id="dtb735" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_73">73</a>
+                            <a id="dtb735" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_73">73</a>
                             <span id="dtb736">.</span>
                         </span>
                     </p>
@@ -1154,7 +1154,7 @@
                     </blockquote>
                     <p>
                         <span id="d910e3394">
-                            <a id="dtb754" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_74">74</a>
+                            <a id="dtb754" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_74">74</a>
                         </span>
                     </p>
                     <p>
@@ -1182,7 +1182,7 @@
                     </blockquote>
                     <p>
                         <span id="d910e3443">
-                            <a id="dtb764" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_75">75</a>
+                            <a id="dtb764" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_75">75</a>
                             <span id="dtb765">.</span>
                         </span>
                     </p>
@@ -1200,7 +1200,7 @@
                     <span id="dtb771">During his years of teaching, Haüy continued to take an interest in ciphers and codes. </span>
                     <span id="d910e3483">
                         <span id="dtb772">He was, for example, very interested in the telegraph and its use in military intelligence </span>
-                        <a id="dtb773" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_76">76</a>
+                        <a id="dtb773" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_76">76</a>
                         <span id="dtb774"> (this was before electricity was in general use). </span>
                     </span>
                     <span id="dtb775">Haüy also probably saw the telegraph as a means of earning money. </span>
@@ -1209,7 +1209,7 @@
                     <span id="d910e3505">
                         <span id="dtb778">In a letter dated 1st July 1807, he described his invention and enclosed a brochure entitled Mémoire historique abrévé sur les télégraphes en général et sur les
                             télégraphes de St Pétersbourg 1801 </span>
-                        <a id="dtb779" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_77">77</a>
+                        <a id="dtb779" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_77">77</a>
                         <span id="dtb780">. </span>
                     </span>
                 </p>
@@ -1248,7 +1248,7 @@
                 </blockquote>
                 <p>
                     <span id="d910e3593">
-                        <a id="dtb798" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_78">78</a>
+                        <a id="dtb798" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_78">78</a>
                         <span id="dtb799">. </span>
                     </span>
                 </p>
@@ -1259,7 +1259,7 @@
                     <span id="dtb803">He was given the opportunity to test his pasigraph between the fortress of Kronstad and a frigate anchored seven verst off the coast of St Petersburg. </span>
                     <span id="d910e3618">
                         <span id="dtb804">The experiment was successful as to speed and precision; however, it is not known what became of Haüy's telegraph </span>
-                        <a id="dtb805" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_79">79</a>
+                        <a id="dtb805" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_79">79</a>
                         <span id="dtb806">. </span>
                     </span>
                 </p>
@@ -1270,13 +1270,13 @@
                     <span id="dtb808">After the defeat of Napoleon at Waterloo in 1814, the National Institute in Paris became once more an autonomous entity. </span>
                     <span id="d910e3646">
                         <span id="dtb809">The new director was Sebastien Guillé, a doctor of medicine, a fanatical royalist and an orthodox Roman Catholic </span>
-                        <a id="dtb810" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_80">80</a>
+                        <a id="dtb810" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_80">80</a>
                         <span id="dtb811">. </span>
                     </span>
                     <span id="dtb812">He forbade Haüy to visit the school since he considered that he had betrayed the French monarchy during the Revolution. </span>
                     <span id="d910e3661">
                         <span id="dtb813">He was particularly critical of Haüy's attitude to religion </span>
-                        <a id="dtb814" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_81">81</a>
+                        <a id="dtb814" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_81">81</a>
                         <span id="dtb815">. </span>
                     </span>
                 </p>

--- a/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
@@ -175,7 +175,7 @@
                         <span id="dtb232">.</span>
                     </span>
                 </p>
-                <div id="page_8" class="page-normal" epub:type="pagebreak" title="8"></div>
+                <div id="page_8" class="page-normal" epub:type="pagebreak" aria-label="8"></div>
                 <p>
                     <span id="dtb233">With the support of the Société Philanthropique,Valentin Haüy founded the first special school for blind children and adolescents in 1784.</span>
                 </p>
@@ -248,7 +248,7 @@
                     <span id="dtb270">He was also upset by the callousness of the audience, who howled with laughter at this shambles of an orchestra. </span>
                     <span id="dtb271">Haüy did not see any reason to laugh at people just because they had a physical impediment.</span>
                 </p>
-                <div id="page_9" class="page-normal" epub:type="pagebreak" title="9"></div>
+                <div id="page_9" class="page-normal" epub:type="pagebreak" aria-label="9"></div>
                 <p>
                     <span id="dtb272">From that day he decided to dedicate his life to improving the conditions of the blind.</span>
                 </p>
@@ -328,7 +328,7 @@
                         <span id="dtb310">, Haüy repeatedly mentions that several of the tools he recommended for the teaching of blind children had been used by Maria Theresia von Paradis. </span>
                     </span>
                 </p>
-                <div id="page_10" class="page-normal" epub:type="pagebreak" title="10"></div>
+                <div id="page_10" class="page-normal" epub:type="pagebreak" aria-label="10"></div>
             </section>
             <section id="d910e1519">
                 <h2 id="d910e1521">3.5 Haüy's meeting with Lesueur and the founding of l'Institution des Jeunes Aveugles</h2>
@@ -418,7 +418,7 @@
                         <span id="dtb363">.</span>
                     </span>
                 </p>
-                <div id="page_11" class="page-normal" epub:type="pagebreak" title="11"></div>
+                <div id="page_11" class="page-normal" epub:type="pagebreak" aria-label="11"></div>
                 <p>
                     <span id="dtb364">Twice a year the blind children performed before the Court. </span>
                     <span id="dtb365">Louis XVI was patron of the institute and also contributed economically to its upkeep. </span>
@@ -491,7 +491,7 @@
                     <span id="dtb394">Each subject is dealt with in a short chapter. </span>
                     <span id="dtb395">Haüy gives simple, practical advice on teaching methods and on the production of material for use in object lessons and of a variety of teaching aids.</span>
                 </p>
-                <div id="page_12" class="page-normal" epub:type="pagebreak" title="12"></div>
+                <div id="page_12" class="page-normal" epub:type="pagebreak" aria-label="12"></div>
                 <p>
                     <span id="dtb396">He lays particular stress on the methods to be used to teach blind children to read and write and on how to produce raised print books. </span>
                     <span id="dtb397">An entire chapter is dedicated to explaining how blind pupils can be trained as compositors. </span>
@@ -560,7 +560,7 @@
                     </span>
                     <span id="dtb435">Although Haüy had raised scores made, he did not at first consider music to be anything more than an entertainment for the blind.</span>
                 </p>
-                <div id="page_13" class="page-normal" epub:type="pagebreak" title="13"></div>
+                <div id="page_13" class="page-normal" epub:type="pagebreak" aria-label="13"></div>
                 <p>
                     <span id="d910e2056">
                         <span id="dtb436">He changed his opinion later when he discovered that the blind could learn to play the organ and thus could be employed as church organists </span>
@@ -648,7 +648,7 @@
                         <span id="dtb483">. </span>
                     </span>
                 </p>
-                <div id="page_14" class="page-normal" epub:type="pagebreak" title="14"></div>
+                <div id="page_14" class="page-normal" epub:type="pagebreak" aria-label="14"></div>
                 <p>
                     <span id="dtb484">Under the monarchy, his blind pupils regularly appeared in public to demonstrate their progress and these performances continued during the revolutionary period. </span>
                     <span id="dtb485">Haüy's ability to adapt to the different régimes would later go against him, however. </span>
@@ -721,7 +721,7 @@
                         <span id="dtb527">.</span>
                     </span>
                 </p>
-                <div id="page_15" class="page-normal" epub:type="pagebreak" title="15"></div>
+                <div id="page_15" class="page-normal" epub:type="pagebreak" aria-label="15"></div>
             </section>
             <section id="d910e2441">
                 <h2 id="d910e2443">3.9 Valentin Haüy in Russia</h2>
@@ -790,7 +790,7 @@
                             in advance when Haüy began his work. </span>
                         <span id="dtb563">He also asked the crown to provide, at no cost to himself, a furnished house, light and fuel.</span>
                     </p>
-                    <div id="page_16" class="page-normal" epub:type="pagebreak" title="16"></div>
+                    <div id="page_16" class="page-normal" epub:type="pagebreak" aria-label="16"></div>
                     <p>
                         <span id="dtb564">Finally, he asked for <span id="d910e2601" class="num-with-space">2 000</span> roubles in advance, as travel allowance for himself and his blind pupil. </span>
                         <span id="dtb565">Haüy did not ask for travel allowances for his wife and son, who accompanied him to Russia. </span>
@@ -864,7 +864,7 @@
                         </span>
                         <span id="dtb601">Eight days after Haüy presented his petition, the money he had been promised was paid.</span>
                     </p>
-                    <div id="page_17" class="page-normal" epub:type="pagebreak" title="17"></div>
+                    <div id="page_17" class="page-normal" epub:type="pagebreak" aria-label="17"></div>
                     <p>
                         <span id="dtb602">The person who became head of the new institute for the blind was a certain Bouchoueff, who taught at a school in St Petersburg and claimed he was sufficiently
                             fluent in French to be able to converse with Haüy and learn his pedagogical ideas. </span>
@@ -930,7 +930,7 @@
                         <span id="dtb639">They were Galitch, a student at the Institute of Pedagogy in St Petersburg, and Louet, a French immigrant (a naturalized Russian citizen), who offered to give
                             music classes.</span>
                     </p>
-                    <div id="page_18" class="page-normal" epub:type="pagebreak" title="18"></div>
+                    <div id="page_18" class="page-normal" epub:type="pagebreak" aria-label="18"></div>
                     <p>
                         <span id="dtb640">Galitch taught a pupil who came from the Kronstadt fortress in the Bay of Finland and who spoke only Russian. </span>
                         <span id="dtb641">According to Skrébitsky, Bouchoueff had already lost heart in his work.</span>
@@ -983,7 +983,7 @@
                                 for this kind of education, which demands knowledge beyond what is expected in ordinary schools.</span>
                         </p>
                     </blockquote>
-                    <div id="page_19" class="page-normal" epub:type="pagebreak" title="19"></div>
+                    <div id="page_19" class="page-normal" epub:type="pagebreak" aria-label="19"></div>
                     <blockquote id="dtb667">
                         <p>
                             <span id="dtb668">I remain in your service as temporary head of the institute only because my colleague, who at an inopportune moment assured the ministry that he could manage
@@ -1046,7 +1046,7 @@
                             Dolst and Haüy thought the contrary. </span>
                         <span id="dtb697">He was also very critical of Haüy, who he found had made improper use of his position by appropriating the best rooms for his own personal use.</span>
                     </p>
-                    <div id="page_20" class="page-normal" epub:type="pagebreak" title="20"></div>
+                    <div id="page_20" class="page-normal" epub:type="pagebreak" aria-label="20"></div>
                     <p>
                         <span id="dtb698">The children's dormitory was cold in winter and stiflingly hot in summer. </span>
                         <span id="dtb699">To make matters worse, they were obliged to pass through the bedroom to empty their chamber pots. </span>
@@ -1106,7 +1106,7 @@
                                 post. </span>
                             <span id="dtb730">I have already nominated young Vaganoff as a worthy successor to this post.</span>
                         </p>
-                        <div id="page_21" class="page-normal" epub:type="pagebreak" title="21"></div>
+                        <div id="page_21" class="page-normal" epub:type="pagebreak" aria-label="21"></div>
                         <p>
                             <span id="dtb731">(3) The minister, rather than the inspector, who does more harm than good, must appoint a person who will direct only the teaching of such handicrafts as may
                                 prepare the blind pupils for a trade. (4) For Fournier's post, the ministry should appoint the three blind pupils Smourof, Vemblad and Stiaguine and have them divide his
@@ -1173,7 +1173,7 @@
                                 I was filled with a desire to defend them to the utmost, if they should indeed require my help.</span>
                         </p>
                     </blockquote>
-                    <div id="page_22" class="page-normal" epub:type="pagebreak" title="22"></div>
+                    <div id="page_22" class="page-normal" epub:type="pagebreak" aria-label="22"></div>
                     <blockquote id="dtb762">
                         <p>
                             <span id="dtb763">M. l'abbé Sicard receives daily proof of the intelligence of the deaf-dumb when he gives them written exercises, when he makes them understand and when he
@@ -1280,7 +1280,7 @@
                         <span id="dtb815">. </span>
                     </span>
                 </p>
-                <div id="page_23" class="page-normal" epub:type="pagebreak" title="23"></div>
+                <div id="page_23" class="page-normal" epub:type="pagebreak" aria-label="23"></div>
                 <p>
                     <span id="dtb816">Not until 1821 was Valentin Haüy able to revisit his old school, which had then been extended to admit some 60 pupils. </span>
                     <span id="dtb817">During a ceremony held on 21st August 1821, Haüy was honoured for his pioneering work in the education of the blind. </span>

--- a/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-06-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-07-rearnotes.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-07-rearnotes.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-07-rearnotes.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-07-rearnotes.xhtml
@@ -111,14 +111,430 @@
         <section id="rearnotes_body" epub:type="bodymatter rearnotes">
             <div id="page_31_special" class="page-special" epub:type="pagebreak" title="31"></div>
             <h1 id="rearnotes_h1">Rearnotes</h1>
-            <p>See <a href="#f01001" role="doc-noteref" epub:type="noteref" class="noteref">[1]</a>.</p>
+            <p>See <a id="f_01001" href="#f01001" role="doc-noteref" epub:type="noteref" class="noteref">[1]</a>.</p>
 
-            <section id="endnote_section" epub:type="endnotes" role="doc-endnotes">
-                <h2>End Notes</h2>
+            <section epub:type="endnotes" id="endnotes-0" role="doc-endnotes">
+                <h2>End notes</h2>
                 <ol>
-                    <li epub:type="endnote" class="notebody" id="f01001">
-                        <p>REARNOTE</p>
+                    <li class="notebody" epub:type="endnote" id="fn_1">
+                        <p>Note</p>
+                        <p><a href="C00000-05-chapter.xhtml#dtb150" role="doc-backlink">Go to the note reference.</a></p>
                     </li>
+                    <li class="notebody" epub:type="endnote" id="fn_2">
+                        <p>Note</p>
+                        <p><a href="C00000-05-chapter.xhtml#dtb155" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_3">
+                        <p>Note</p>
+                        <p><a href="C00000-05-chapter.xhtml#dtb160" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_4">
+                        <p>Note</p>
+                        <p><a href="C00000-05-chapter.xhtml#dtb182" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_5">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb203" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_6">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb206" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_7">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb209" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_8">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb212" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_9">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb218" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_10">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb224" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_11">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb228" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_12">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb231" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_13">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb235" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_14">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb244" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_15">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb252" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_16">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb258" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_17">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb261" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_18">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb265" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_19">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb280" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_20">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb287" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_21">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb297" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_22">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb303" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_23">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb306" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_24">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb309" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_25">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb313" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+
+                    <li class="notebody" epub:type="endnote" id="fn_26">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb319" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_27">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb322" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_28">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb325" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_29">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb338" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_30">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb343" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_31">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb348" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_32">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb353" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_33">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb357" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_34">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb362" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_35">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb371" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_36">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb403" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_37">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb406" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_38">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb411" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_39">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb417" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_40">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb426" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_41">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb433" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_42">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb437" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_43">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb440" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_44">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb445" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_45">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb448" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_46">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb457" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_47">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb462" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_48">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb471" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_49">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb476" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_50">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb480" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_51">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb482" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_52">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb487" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_53">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb491" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_54">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb500" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_55">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb503" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_56">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb509" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_57">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb515" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_58">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb526" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_59">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb532" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_60">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb537" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_61">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb539" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_62">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb553" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_63">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb575" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_64">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb579" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_65">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb583" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_66">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb586" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_67">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb593" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_68">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb599" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_69">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb614" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_70">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb632" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_71">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb636" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_72">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb676" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_73">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb735" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_74">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb754" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_75">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb764" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_76">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb773" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_77">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb779" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_78">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb798" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_79">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb805" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_80">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb810" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_81">
+                        <p>Note</p>
+                        <p><a href="C00000-06-chapter.xhtml#dtb814" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_82">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb823" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_83">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb832" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_84">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb835" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_85">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb839" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_86">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb843" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_87">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb850" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_88">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb855" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_89">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb859" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_90">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb865" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_91">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb870" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_92">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb875" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_93">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb883" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_94">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb888" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_95">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb897" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_96">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb902" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_97">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb922" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_98">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb814" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_99">
+                        <p>Note</p>
+                        <p><a href="C00000-08-chapter.xhtml#dtb814" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_100">
+                        <p>Note</p>
+                        <p><a href="C00000-11-conclusion.xhtml#dtb983" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_101">
+                        <p>Note</p>
+                        <p><a href="C00000-11-conclusion.xhtml#dtb986" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_102">
+                        <p>Note</p>
+                        <p><a href="C00000-11-conclusion.xhtml#dtb997" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+                    <li class="notebody" epub:type="endnote" id="fn_103">
+                        <p>Note</p>
+                        <p><a href="C00000-11-conclusion.xhtml#dtb1008" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+
+                    <li class="notebody" epub:type="endnote" id="f01001">
+                        <p>Note</p>
+                        <p><a href="#f_01001" role="doc-backlink">Go to the note reference.</a></p>
+                    </li>
+
                 </ol>
             </section>
         </section>

--- a/client/src/test/resources/valid2020/EPUB/C00000-07-rearnotes.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-07-rearnotes.xhtml
@@ -113,8 +113,8 @@
             <h1 id="rearnotes_h1">Rearnotes</h1>
             <p>See <a id="f_01001" href="#f01001" role="doc-noteref" epub:type="noteref" class="noteref">[1]</a>.</p>
 
-            <section epub:type="endnotes" id="endnotes-0" role="doc-endnotes">
-                <h2>End notes</h2>
+            <section epub:type="endnotes" id="endnote_section" role="doc-endnotes">
+                <h2>End Notes</h2>
                 <ol>
                     <li class="notebody" epub:type="endnote" id="fn_1">
                         <p>Note</p>
@@ -507,11 +507,11 @@
                     </li>
                     <li class="notebody" epub:type="endnote" id="fn_98">
                         <p>Note</p>
-                        <p><a href="C00000-08-chapter.xhtml#dtb814" role="doc-backlink">Go to the note reference.</a></p>
+                        <p><a href="C00000-08-conclusion.xhtml#dtb954" role="doc-backlink">Go to the note reference.</a></p>
                     </li>
                     <li class="notebody" epub:type="endnote" id="fn_99">
                         <p>Note</p>
-                        <p><a href="C00000-08-chapter.xhtml#dtb814" role="doc-backlink">Go to the note reference.</a></p>
+                        <p><a href="C00000-08-conclusion.xhtml#dtb962" role="doc-backlink">Go to the note reference.</a></p>
                     </li>
                     <li class="notebody" epub:type="endnote" id="fn_100">
                         <p>Note</p>

--- a/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
@@ -113,7 +113,7 @@
             <p>
                 <span id="d910e3707">
                     <span id="dtb822">Blind individuals have probably been educated to some degree or other in a number of countries throughout the world for many centuries </span>
-                    <a id="dtb823" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_82">82</a>
+                    <a id="dtb823" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_82">82</a>
                     <span id="dtb824">. </span>
                 </span>
                 <span id="dtb825">Organised education of the blind, however, did not exist before the end of the 18th century and the beginning of the 19th century.</span>
@@ -130,12 +130,12 @@
                 <span id="dtb830">In both cases John Locke and other Enlightenment philosophers exerted a powerful influence over the pioneers of education for the blind. </span>
                 <span id="d910e3743">
                     <span id="dtb831">Another pioneer in this field was Johan Wilhelm Klein, who in 1804 founded an institute for the blind in Vienna </span>
-                    <a id="dtb832" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_83">83</a>
+                    <a id="dtb832" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_83">83</a>
                     <span id="dtb833">. </span>
                 </span>
                 <span id="d910e3755">
                     <span id="dtb834">From the first, Klein regarded his school as a public concern </span>
-                    <a id="dtb835" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_84">84</a>
+                    <a id="dtb835" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_84">84</a>
                     <span id="dtb836"> and his real wish was to integrate blind children into ordinary classes. </span>
                 </span>
                 <span id="dtb837">Klein's institute was from the outset financed by the State, while the institute which Haüy and Zeune founded in Berlin in 1806 also received State funds.</span>
@@ -143,7 +143,7 @@
             <p>
                 <span id="d910e3773">
                     <span id="dtb838">The birth of Swedish education for the blind is usually considered to have occurred in 1807 </span>
-                    <a id="dtb839" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_85">85</a>
+                    <a id="dtb839" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_85">85</a>
                     <span id="dtb840">. </span>
                 </span>
                 <span id="dtb841">At that time, the Keeper of Royal Records, Pär Aron Borg, received a visit from the 24- year old Charlotta Seijerling, who had become blind at the age of four and later
@@ -153,7 +153,7 @@
                         the public examination of Charlotta Seijerling, who was able to demonstrate her skill in reading, singing, playing the piano and the harp and also in "a number of handicrafts,
                         which she had been taught such as spinning, knitting and needlework; and she had, particularly in the latter crafts, acquired such skill that she was able to show a sweater which
                         she had made for herself". </span>
-                    <a id="dtb843" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_86">86</a>
+                    <a id="dtb843" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_86">86</a>
                     <span id="dtb844">. </span>
                 </span>
                 <span id="dtb845">This examination was held prior to the funding of the institute. </span>
@@ -166,7 +166,7 @@
                 <span id="dtb848">In his letter to the king, he also requested permission to teach the deaf. </span>
                 <span id="d910e3816">
                     <span id="dtb849">Borg's petition met with approval and he was granted an annual personal allowance of 450 riksdaler banco </span>
-                    <a id="dtb850" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_87">87</a>
+                    <a id="dtb850" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_87">87</a>
                     <span id="dtb851">. </span>
                 </span>
                 <span id="dtb852">Johansson is of the opinion that this decision led to the establishment in Sweden of an institute for the blind, the deaf and the mentally infirm.</span>
@@ -179,7 +179,7 @@
                 <span id="d910e3843">
                     <span id="dtb854">In his application to the monarch for funds, Borg also committed himself to holding annual public examinations of the institute's pupils, as demanded by the new
                         régime, which at the same time had increased the institute's funding </span>
-                    <a id="dtb855" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_88">88</a>
+                    <a id="dtb855" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_88">88</a>
                     <span id="dtb856">.</span>
                 </span>
             </p>
@@ -187,7 +187,7 @@
                 <span id="dtb857">During the Autumn and Winter of 1808 to 1809, Borg initiated teaching activities on a larger scale, by accepting six deaf pupils and one blind pupil. </span>
                 <span id="d910e3861">
                     <span id="dtb858">Borg claimed that he was familiar with the educational methods in vogue in other countries in Europe, but that he preferred to follow his own ideas </span>
-                    <a id="dtb859" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_89">89</a>
+                    <a id="dtb859" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_89">89</a>
                     <span id="dtb860">. </span>
                 </span>
                 <span id="dtb861">With regard to the deaf, however, he allowed himself to be oriented by l'épée in his use of sign language and the finger alphabet. </span>
@@ -198,7 +198,7 @@
                     which has survived. </span>
                 <span id="d910e3885">
                     <span id="dtb864">Because of the shortage of blind pupils, the institute eventually accepted only deaf children </span>
-                    <a id="dtb865" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_90">90</a>
+                    <a id="dtb865" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_90">90</a>
                     <span id="dtb866">. </span>
                 </span>
                 <span id="dtb867">Pär Aron Borg left the institute in 1818, after a series of conflicts, to found a private institute for the deaf in Manhem.</span>
@@ -208,7 +208,7 @@
                 <span id="d910e3907">
                     <span id="dtb869">During the parliamentary session of 1844 to 1845, education for the disabled was discussed, and in the course of that debate it was in fact suggested that this type
                         of education should be integrated into the general elementary school system </span>
-                    <a id="dtb870" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_91">91</a>
+                    <a id="dtb870" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_91">91</a>
                     <span id="dtb871">. </span>
                 </span>
                 <span id="dtb872">The decision to create a separate school for the blind was taken in the Riddarhus (House of the Nobility) by Nils af Zellén, head of department at the Ministry of
@@ -220,7 +220,7 @@
                 <span id="d910e3928">
                     <span id="dtb874">Ossian Edmund Borg, the son of Pär Aron Borg, had become director of the General Institute for the Deaf at Manilla and was sent on a tour of Denmark, Germany, Belgium
                         and France for the purpose of studying the progress of the education for the blind in these countries </span>
-                    <a id="dtb875" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_92">92</a>
+                    <a id="dtb875" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_92">92</a>
                     <span id="dtb876">. </span>
                 </span>
                 <span id="dtb877">In 1846, the Riksdag (Swedish parliament) decided that a new department for the blind should be established at Manilla. </span>
@@ -230,7 +230,7 @@
                 <span id="dtb881">Musical skills would also be taught. </span>
                 <span id="d910e3956">
                     <span id="dtb882">The children would attend the institute from 12 to 18 years of age </span>
-                    <a id="dtb883" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_93">93</a>
+                    <a id="dtb883" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_93">93</a>
                     <span id="dtb884">. </span>
                 </span>
                 <span id="dtb885">Prior to that, they would be admitted to the school in the locality in which they officially resided.</span>
@@ -239,7 +239,7 @@
                 <span id="dtb886">In Denmark, the situation was somewhat different. </span>
                 <span id="d910e3977">
                     <span id="dtb887">The Kjaeden Order had been founded towards the end of the 18th century; one of its activities was helping the blind </span>
-                    <a id="dtb888" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_94">94</a>
+                    <a id="dtb888" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_94">94</a>
                     <span id="dtb889">. </span>
                 </span>
                 <span id="dtb890">Originally the Order ran an asylum which admitted a certain number of blind persons who were taught handicrafts. </span>
@@ -259,7 +259,7 @@
                 <span id="d910e4016">
                     <span id="dtb896">A letter from Castberg, however, contains an interesting piece of information; he mentions that during his stay in Paris he tried to buy Haüy's book but that only
                         second-hand copies were to be had </span>
-                    <a id="dtb897" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_95">95</a>
+                    <a id="dtb897" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_95">95</a>
                     <span id="dtb898">. </span>
                 </span>
                 <span id="dtb899">He bought three copies, one of which he kept for himself. </span>
@@ -269,7 +269,7 @@
                 <span id="d910e4038">
                     <span id="dtb901">A pamphlet entitled Journal udgiven til Fordel for Blinde was published in 1811 in Copenhagen in which an article on Haüy, written by Daniel Fürst, a merchant,
                         appeared </span>
-                    <a id="dtb902" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_96">96</a>
+                    <a id="dtb902" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_96">96</a>
                     <span id="dtb903">. </span>
                 </span>
                 <span id="dtb904">Fürst writes that he spent six months in 1805 in daily contact with Haüy and that he had learned how to teach the blind from him. </span>
@@ -295,7 +295,7 @@
                 <span id="dtb920">Melchior who had visited the institute in Paris in 1852 and seen for himself that blind pupils could learn to read with the help of raised print books. </span>
                 <span id="d910e4106">
                     <span id="dtb921">He later stated in his report that the Danish institute had not kept up with developments in this field </span>
-                    <a id="dtb922" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_97">97</a>
+                    <a id="dtb922" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_97">97</a>
                     <span id="dtb923">. </span>
                 </span>
                 <span id="dtb924">As a result of Melchior's report, the commission suggested that the institute should employ special teachers to teach the blind pupils to read and write. </span>

--- a/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-08-chapter.xhtml
@@ -171,7 +171,7 @@
                 </span>
                 <span id="dtb852">Johansson is of the opinion that this decision led to the establishment in Sweden of an institute for the blind, the deaf and the mentally infirm.</span>
             </p>
-            <div id="page_24" class="page-normal" epub:type="pagebreak" title="24"></div>
+            <div id="page_24" class="page-normal" epub:type="pagebreak" aria-label="24"></div>
             <p>
                 <span id="dtb853">The allowance continued to be paid after the events of March 1809, when Gustav IV Adolf was forced to abdicate in favour of his uncle (Carl XIII).</span>
             </p>
@@ -251,7 +251,7 @@
                     organisation of the institutes for the blind which exist in Paris, where the blind, each according to his capacity, are educated to become useful citizens since they are taught
                     different skills in the production of a variety of articles."</span>
             </p>
-            <div id="page_25" class="page-normal" epub:type="pagebreak" title="25"></div>
+            <div id="page_25" class="page-normal" epub:type="pagebreak" aria-label="25"></div>
             <p>
                 <span id="dtb894">Castberg spent the winter of 1804 to 1805 in Paris but there is no written testimony of his having informed the Institute for Blind Youth in Copenhagen of what he had
                     observed. </span>
@@ -322,7 +322,7 @@
                     <img alt="image" src="images/valentin.jpg" id="img_5" />
                 </figure>
             </figure>
-            <div id="page_26" class="page-normal" epub:type="pagebreak" title="26"></div>
+            <div id="page_26" class="page-normal" epub:type="pagebreak" aria-label="26"></div>
             <p>
                 <span id="dtb929">In 1855, Haüy's Essai sur l'Education des Aveugles was translated into Danish by a young blind man by the name of Hans S/ondring. </span>
                 <span id="dtb930">The Danish translation was called Om de Blinde (About the Blind). </span>

--- a/client/src/test/resources/valid2020/EPUB/C00000-09-part.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-09-part.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-10-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-10-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <style type="text/css" xml:space="preserve">

--- a/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
@@ -105,7 +105,7 @@
             }</style>
         <link rel="stylesheet" type="text/css" href="css/accessibility.css" />
         <link rel="prev" href="C00000-10-chapter.xhtml" />
-        <link rel="next" href="C00000-12-footnotes.xhtml" />
+        <link rel="next" href="C00000-07-rearnotes.xhtml" />
     </head>
     <body>
         <section id="d910e4160" epub:type="bodymatter conclusion">
@@ -141,7 +141,7 @@
                 <span id="dtb952">But is this so remarkable? </span>
                 <span id="d910e4242">
                     <span id="dtb953">He moved in precisely those circles - mainly composed of academics and public officials - from which the French Revolution sprang </span>
-                    <a id="dtb954" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_98">98</a>
+                    <a id="dtb954" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_98">98</a>
                     <span id="dtb955">.</span>
                 </span>
             </p>
@@ -158,7 +158,7 @@
                 <span id="d910e4278">
                     <span id="dtb961">Haüy does not stand alone amongst his contemporaries in taking this utilitarian view of education for the visually impaired: it was characteristic of all teaching
                         during the period of the French Revolution </span>
-                    <a id="dtb962" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_99">99</a>
+                    <a id="dtb962" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_99">99</a>
                     <span id="dtb963">.</span>
                 </span>
             </p>
@@ -196,14 +196,14 @@
                 <span id="dtb981">It remained in use until modern computer technology made it possible to produce tactile writing. </span>
                 <span id="d910e4364">
                     <span id="dtb982">Indeed, Haüy has sometimes been called "The Gutenberg of the Blind" </span>
-                    <a id="dtb983" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_100">100</a>
+                    <a id="dtb983" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_100">100</a>
                     <span id="dtb984">.</span>
                 </span>
             </p>
             <p>
                 <span id="d910e4379">
                     <span id="dtb985">Haüy was not a pioneer of object lessons for blind children, although he did continue what others before him had begun </span>
-                    <a id="dtb986" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_101">101</a>
+                    <a id="dtb986" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_101">101</a>
                     <span id="dtb987">. </span>
                 </span>
                 <span id="dtb988">He was more practical in his approach to the problems involved in educating blind children, producing useful material and equipment (such as his printing press) which he
@@ -223,7 +223,7 @@
                     instruire (1819) developed a much more sophisticated theoretical approach to the education of the blind. </span>
                 <span id="d910e4422">
                     <span id="dtb996">While he was director of the institute, however, Guillé did not increase the number of textbooks or teaching aids for use in object lessons </span>
-                    <a id="dtb997" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_102">102</a>
+                    <a id="dtb997" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_102">102</a>
                     <span id="dtb998">.</span>
                 </span>
             </p>
@@ -247,7 +247,7 @@
                 <span id="dtb1006">Madame Haüy remains a mystery and it is impossible to judge her contribution as a teacher. </span>
                 <span id="d910e4470">
                     <span id="dtb1007">All we know is that she taught at both the Musée des Aveugles </span>
-                    <a id="dtb1008" epub:type="noteref" class="noteref" href="C00000-12-footnotes.xhtml#fn_103">103</a>
+                    <a id="dtb1008" epub:type="noteref" class="noteref" href="C00000-07-rearnotes.xhtml#fn_103">103</a>
                     <span id="dtb1009"> and the institute in St Petersburg.</span>
                 </span>
             </p>

--- a/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-11-conclusion.xhtml
@@ -169,7 +169,7 @@
                 <span id="dtb965">I have shown that experimentation in education for visually impaired pupils originated in several countries; there are thus several persons, contemporaries of Haüy, who
                     might well be called pioneers of education for the blind.</span>
             </p>
-            <div id="page_27" class="page-normal" epub:type="pagebreak" title="27"></div>
+            <div id="page_27" class="page-normal" epub:type="pagebreak" aria-label="27"></div>
             <p>
                 <span id="dtb966">Pritchard (1963), however, emphasises that Haüy was unique in that he created a system of organised education for the blind based on a carefully thought-out method. </span>
                 <span id="dtb967">The outstanding feature of Haüy's enterprise - which sets him apart from British pedagogues of the time - was the founding of a school in the true sense, which imparted
@@ -227,7 +227,7 @@
                     <span id="dtb998">.</span>
                 </span>
             </p>
-            <div id="page_28" class="page-normal" epub:type="pagebreak" title="28"></div>
+            <div id="page_28" class="page-normal" epub:type="pagebreak" aria-label="28"></div>
             <p>
                 <span id="dtb999">Then we come to the question: Did Haüy in fact found an institute for the blind in St Petersburg?</span>
             </p>

--- a/client/src/test/resources/valid2020/EPUB/C00000-12-toc.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-12-toc.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
 <head xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
     <meta charset="UTF-8" />
-    <title>FRIEDRICH NIETZSCHE IN SEINEN WERKEN</title>
+    <title>Valentin Haüy - the father of the education for the blind</title>
     <meta name="dc:identifier" content="X50525A" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="css/default.css" />
@@ -355,7 +355,8 @@
             Archive Foundation, how to help produce our new eBooks, and how to
             subscribe to our email newsletter to hear about new eBooks.</p>
     </section>
-</section>
+
+    </section>
 </section>
 </body>
 </html>

--- a/client/src/test/resources/valid2020/EPUB/C00000-12-toc.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-12-toc.xhtml
@@ -4,7 +4,7 @@
 <head xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
     <meta charset="UTF-8" />
     <title>Valentin Haüy - the father of the education for the blind</title>
-    <meta name="dc:identifier" content="X50525A" />
+    <meta name="dc:identifier" content="C00000" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="css/default.css" />
 </head>

--- a/client/src/test/resources/valid2020/EPUB/C00000-12-toc.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-12-toc.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
 <head xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
     <meta charset="UTF-8" />
-    <title>Valentin Haüy - the father of the education for the blind</title>
+    <title>Valentin Haüy</title>
     <meta name="dc:identifier" content="C00000" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="css/default.css" />

--- a/client/src/test/resources/valid2020/EPUB/C00000-13-part.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-13-part.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-14-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-14-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-15-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-15-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-16-part.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-16-part.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/C00000-17-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-17-chapter.xhtml
@@ -6,7 +6,7 @@
     xmlns:nordic="http://www.mtm.se/epub/">
     <head>
         <meta charset="UTF-8" />
-        <title>Valentin Haüy - the father of the education for the blind</title>
+        <title>Valentin Haüy</title>
         <meta content="C00000" name="dc:identifier" />
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="css/accessibility.css"/>

--- a/client/src/test/resources/valid2020/EPUB/nav.ncx
+++ b/client/src/test/resources/valid2020/EPUB/nav.ncx
@@ -329,25 +329,25 @@
             <navLabel>
                 <text>iii</text>
             </navLabel>
-            <content src="C00000-02-toc.xhtml#page_3"/>
+            <content src="C00000-02-toc.xhtml#page_front_3"/>
         </pageTarget>
         <pageTarget id="pageTarget-35" playOrder="35" type="normal">
             <navLabel>
                 <text>iv</text>
             </navLabel>
-            <content src="C00000-03-frontmatter.xhtml#page_4"/>
+            <content src="C00000-03-frontmatter.xhtml#page_front_4"/>
         </pageTarget>
         <pageTarget id="pageTarget-35" playOrder="35" type="normal">
             <navLabel>
                 <text>vii</text>
             </navLabel>
-            <content src="C00000-03-frontmatter.xhtml#page-vii"/>
+            <content src="C00000-03-frontmatter.xhtml#page_front_7"/>
         </pageTarget>
         <pageTarget id="pageTarget-35" playOrder="35" type="normal">
             <navLabel>
                 <text>viii</text>
             </navLabel>
-            <content src="C00000-03-frontmatter.xhtml#page-viii"/>
+            <content src="C00000-03-frontmatter.xhtml#page_front_8"/>
         </pageTarget>
         <pageTarget id="pageTarget-36" playOrder="36" type="normal">
             <navLabel>

--- a/client/src/test/resources/valid2020/EPUB/nav.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/nav.xhtml
@@ -290,10 +290,10 @@
         <nav epub:type="page-list" hidden="">
             <h1>List of pages</h1>
             <ol>
-                <li><a href="C00000-02-toc.xhtml#page_3">iii</a></li>
-                <li><a href="C00000-03-frontmatter.xhtml#page_4">iv</a></li>
-                <li><a href="C00000-03-frontmatter.xhtml#page-vii">vii</a></li>
-                <li><a href="C00000-03-frontmatter.xhtml#page-viii">viii</a></li>
+                <li><a href="C00000-02-toc.xhtml#page_front_3">iii</a></li>
+                <li><a href="C00000-03-frontmatter.xhtml#page_front_4">iv</a></li>
+                <li><a href="C00000-03-frontmatter.xhtml#page_front_7">vii</a></li>
+                <li><a href="C00000-03-frontmatter.xhtml#page_front_8">viii</a></li>
                 <li><a href="C00000-03-frontmatter.xhtml#page_front_5">v</a></li>
                 <li><a href="C00000-04-chapter.xhtml#page_5">5</a></li>
                 <li><a href="C00000-05-chapter.xhtml#page_6">6</a></li>

--- a/client/src/test/resources/valid2020/EPUB/package.opf
+++ b/client/src/test/resources/valid2020/EPUB/package.opf
@@ -10,7 +10,7 @@
         <dc:identifier id="pub-identifier">C00000</dc:identifier>
         <dc:title id="mymaintitle">Valentin Haüy</dc:title>
         <meta refines="#mymaintitle" property="title-type">main</meta>
-        <dc:title id="mysubtitle"> - the father of the education for the blind</dc:title>
+        <dc:title id="mysubtitle">the father of the education for the blind</dc:title>
         <meta refines="#mysubtitle" property="title-type">subtitle</meta>
         <dc:creator>Beatrice Christensen Sköld</dc:creator>
         <dc:language>en</dc:language>

--- a/client/src/test/resources/valid2020/EPUB/package.opf
+++ b/client/src/test/resources/valid2020/EPUB/package.opf
@@ -10,7 +10,7 @@
         <dc:identifier id="pub-identifier">C00000</dc:identifier>
         <dc:title id="mymaintitle">Valentin Haüy</dc:title>
         <meta refines="#mymaintitle" property="title-type">main</meta>
-        <dc:title id="mysubtitle">the father of the education for the blind</dc:title>
+        <dc:title id="mysubtitle"> - the father of the education for the blind</dc:title>
         <meta refines="#mysubtitle" property="title-type">subtitle</meta>
         <dc:creator>Beatrice Christensen Sköld</dc:creator>
         <dc:language>en</dc:language>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -170,7 +170,7 @@
         <p>The HTML title element must be the same as the OPF publication dc:title</p>
         <rule context="html:title">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <let name="fulltitle" value="//opf:package/opf:metadata/dc:title[1]/text()"/>
+            <let name="fulltitle" value="//opf:package/opf:metadata/dc:title[not(@refines) and position()=1]/text()"/>
             <assert test="text() = $fulltitle">[nordic_opf_and_html_28] The HTML title element in <value-of select="replace(base-uri(.),'.*/','')"/>
                 must contain the same text as the dc:title element in the OPF metadata. The HTML title element contains "<value-of select="."/>" while the dc:title element in the OPF contains
                     "<value-of select="$fulltitle"/>".</assert>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -170,7 +170,7 @@
         <p>The HTML title element must be the same as the OPF publication dc:title</p>
         <rule context="html:title">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <let name="fulltitle" value="string-join(/*/opf:package/opf:metadata/dc:title[not(@refines)]/text(), ' - ')"/>
+            <let name="fulltitle" value="//opf:package/opf:metadata/dc:title[1]/text()"/>
             <assert test="text() = $fulltitle">[nordic_opf_and_html_28] The HTML title element in <value-of select="replace(base-uri(.),'.*/','')"/>
                 must contain the same text as the dc:title element in the OPF metadata. The HTML title element contains "<value-of select="."/>" while the dc:title element in the OPF contains
                     "<value-of select="$fulltitle"/>".</assert>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -135,7 +135,7 @@
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <!-- this is the multi-HTML version of the rule; the single-HTML version of this rule is in nordic2015-1.sch -->
 
-        <assert test="count(//html:*[tokenize(@epub:type,'\s+')=('note','endnote','footnote') and @id = current()/substring-after(@href,'#')]) &gt;= 1">[nordic_opf_and_html_26b] The note
+            <assert test="count(//html:*[tokenize(@epub:type,'\s+')=('note','endnote','footnote') and @id = current()/substring-after(@href,'#')]) &gt;= 1">[nordic_opf_and_html_26b] The note
                 reference with the href "<value-of select="@href"/>" attribute must resolve to a note, endnote or footnote in the publication: <value-of select="$context"/> (in <value-of select="replace(base-uri(),'.*/','')"
                 />)</assert>
         </rule>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -134,7 +134,8 @@
         <rule context="html:a[tokenize(@epub:type,'\s+')='noteref']">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
             <!-- this is the multi-HTML version of the rule; the single-HTML version of this rule is in nordic2015-1.sch -->
-            <assert test="count(//html:*[tokenize(@role,'\s+')=('doc-endnote','doc-footnote') and @id = current()/substring-after(@href,'#')]) &gt;= 1">[nordic_opf_and_html_26b] The note
+
+        <assert test="count(//html:*[tokenize(@epub:type,'\s+')=('note','endnote','footnote') and @id = current()/substring-after(@href,'#')]) &gt;= 1">[nordic_opf_and_html_26b] The note
                 reference with the href "<value-of select="@href"/>" attribute must resolve to a note, endnote or footnote in the publication: <value-of select="$context"/> (in <value-of select="replace(base-uri(),'.*/','')"
                 />)</assert>
         </rule>

--- a/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
+++ b/src/main/resources/xml/schema/2020-1/nordic2020-1.opf-and-html.sch
@@ -170,9 +170,10 @@
         <p>The HTML title element must be the same as the OPF publication dc:title</p>
         <rule context="html:title">
             <let name="context" value="concat('(&lt;', name(), string-join(for $a in (@*) return concat(' ', $a/name(), '=&quot;', $a, '&quot;'), ''), '&gt;)')"/>
-            <assert test="text() = /*/opf:package/opf:metadata/dc:title[not(@refines)]/text()">[nordic_opf_and_html_28] The HTML title element in <value-of select="replace(base-uri(.),'.*/','')"/>
+            <let name="fulltitle" value="string-join(/*/opf:package/opf:metadata/dc:title[not(@refines)]/text(), ' - ')"/>
+            <assert test="text() = $fulltitle">[nordic_opf_and_html_28] The HTML title element in <value-of select="replace(base-uri(.),'.*/','')"/>
                 must contain the same text as the dc:title element in the OPF metadata. The HTML title element contains "<value-of select="."/>" while the dc:title element in the OPF contains
-                    "<value-of select="/*/opf:package/opf:metadata/dc:title[not(@refines)]/text()"/>".</assert>
+                    "<value-of select="$fulltitle"/>".</assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Hi @josteinaj and @martinpub 

This PR tries to solve the issue of the `endnote` role not being allowed. This is more described in https://github.com/nlbdev/nordic-epub3-dtbook-migrator/issues/556

I made two changes to the rules.
* Endnote roles are not used to find backlinks to verify that all backlinks are correct. We will use the endnote `epub:type` instead.
* dc:title metadata tags will be concatenated with `string-join` using the pattern " - " so we will get spaces and a dash between each part of the title. That will then be checked against each content document title.

As you see, there are many changes, but the main thing here is that I created a test to verify the validity of our test case and found many issues. 

* Title content document did not match the package
* id's was not unique
* some page breaks used title instead of aria-label
* refereed notes were missing
* dc:identifier in the content document did not match package file dc:identifier

I'm not sure if verifying all the test changes is interesting but you might have an input on the minor rule changes I made.

Best regards
Daniel