### PR TITLE
Allow sentences in poems, verses and line-by-line constructions.

### DIFF
--- a/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
+++ b/client/src/test/resources/valid2020/EPUB/C00000-04-chapter.xhtml
@@ -170,19 +170,19 @@
 
             <div class="verse" id="test_1" title="This is a poem" xml:space="default" xml:lang="en" lang="en" dir="ltr">
                 <p class="linegroup">
-                    <span class="line"><span class="linenum">1</span> This is line one</span><br/>
-                    <span class="line"><span class="linenum">2</span> This is line two</span><br/>
-                    <span class="line"><span class="linenum">3</span> This is line three</span><br/>
-                    <span class="line"><span class="linenum">4</span> This is line four</span>
+                    <span class="line sentence"><span class="linenum">1</span> This is line one</span><br/>
+                    <span class="line sentence"><span class="linenum">2</span> This is line two</span><br/>
+                    <span class="line sentence"><span class="linenum">3</span> This is line three</span><br/>
+                    <span class="line sentence"><span class="linenum">4</span> This is line four</span>
                 </p>
             </div>
 
             <div class="line-by-line">
-                <p class="linegroup"><span class="line"><span class="linenum">1</span> This is line one</span></p>
-                <p class="linegroup"><span class="line"><span class="linenum">2</span> This is line two</span></p>
+                <p class="linegroup"><span class="line sentence"><span class="linenum">1</span> This is line one</span></p>
+                <p class="linegroup"><span class="line sentence"><span class="linenum">2</span> This is line two</span></p>
                 <hr class="separator"/>
-                <p class="linegroup"><span class="line"><span class="linenum">3</span> This is line three</span></p>
-                <p class="linegroup"><span class="line"><span class="linenum">4</span> This is line four</span></p>
+                <p class="linegroup"><span class="line sentence"><span class="linenum">3</span> This is line three</span></p>
+                <p class="linegroup"><span class="line sentence"><span class="linenum">4</span> This is line four</span></p>
             </div>
 
             <aside class="text-box" id="sidebar_6">

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -2289,9 +2289,11 @@
                             <value>line</value>
                             <value>line_indent</value>
                             <value>line_longindent</value>
-                            <value>sentence</value>
                         </choice>
                     </oneOrMore>
+                    <optional>
+                        <value>sentence</value>
+                    </optional>
                 </list>
             </attribute>
             <zeroOrMore>

--- a/src/main/resources/xml/schema/2020-1/nordic-html5.rng
+++ b/src/main/resources/xml/schema/2020-1/nordic-html5.rng
@@ -2289,6 +2289,7 @@
                             <value>line</value>
                             <value>line_indent</value>
                             <value>line_longindent</value>
+                            <value>sentence</value>
                         </choice>
                     </oneOrMore>
                 </list>


### PR DESCRIPTION
Hi @josteinaj 

After producing books with sentence markup for MTM with poems, verse, and line-by-line constructions, we saw that adding classification for sentences was not allowed and would add extra unnessarary complexity to the format if we didn't do a minor change to the validator.

This will allow the lines of these constructions to also carry the sentence class for use in narrating systems.

Best regards
Daniel