### PR TITLE
Fix crash when title has inline elements

### DIFF
--- a/src/main/resources/xml/xslt/2020-1/list-heading-and-pagebreak-references.xsl
+++ b/src/main/resources/xml/xslt/2020-1/list-heading-and-pagebreak-references.xsl
@@ -48,7 +48,7 @@
             <xsl:attribute name="data-sectioning-depth" select="count(ancestor::section | ancestor::article)"/>
             <xsl:value-of select="
                 if (./span/@epub:type = 'title') then
-                    normalize-space(./span[tokenize(@epub:type,'\s+') = 'title']/text())
+                    normalize-space(string-join(./span[tokenize(@epub:type,'\s+') = 'title']//text()))
                 else
                     normalize-space(string-join(.//text() except .//*[tokenize(@epub:type,'\s+') = 'noteref']//text(),''))
             "/>


### PR DESCRIPTION
The validator currently crashes if it encounters a title element like the one below:

```xml
<section aria-labelledby="d5e1912" epub:type="frontmatter titlepage" id="d5e1907">
  <h1 class="title" epub:type="fulltitle" id="d5e1912">
    <span epub:type="title">
      <strong>Minimal</strong>
    </span>
    <span epub:type="subtitle" role="doc-subtitle">
      <strong>The titlepage</strong>
    </span>
...
```

```
Type error at char 92 in expression in xsl:value-of/@select on line 54 column 17
  XPTY0004  A sequence of more than one item is not allowed as the first argument of
  fn:normalize-space() ("
          ", "
        ")
  In template rule with match="element(Q{http://www.w3.org/1999/xhtml}h1)" on line 18 of
     invoked by xsl:apply-templates at #87
  In template rule with match="element(Q{http://www.w3.org/1999/xhtml}section)" on line 58 of
     invoked by xsl:apply-templates at #9
  In template rule with match="node()" on line 8 of
     invoked by xsl:apply-templates at #14
  In template rule with match="/*" on line 12 of
     invoked by built-in template rule (text-only)
2024-01-09 13:51:29,575 [FATAL|org.daisy.validator.NordicValidator|NordicValidator] A sequence of more than one item is not allowed as the first argument of fn:normalize-space() ("
          ", "
        ")
; SystemID: ; Line#: 54; Column#: 92
net.sf.saxon.trans.XPathException: A sequence of more than one item is not allowed as the first argument of fn:normalize-space() ("
          ", "
        ")
        at net.sf.saxon.expr.Expression.typeError(Expression.java:1478)
        at net.sf.saxon.expr.CardinalityChecker.evaluateItem(CardinalityChecker.java:296)
        at net.sf.saxon.expr.parser.Evaluator$OptionalItem.evaluate(Evaluator.java:201)
        at net.sf.saxon.expr.SystemFunctionCall.evaluateArguments(SystemFunctionCall.java:469)
        at net.sf.saxon.expr.FunctionCall.iterate(FunctionCall.java:560)
        at net.sf.saxon.expr.Expression.process(Expression.java:949)
        at net.sf.saxon.expr.SystemFunctionCall.process(SystemFunctionCall.java:496)
        at net.sf.saxon.expr.instruct.Choose.processLeavingTail(Choose.java:945)
        at net.sf.saxon.expr.instruct.Instruction.process(Instruction.java:142)
        at net.sf.saxon.expr.instruct.ValueOf.processLeavingTail(ValueOf.java:345)
        at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:755)
        at net.sf.saxon.expr.instruct.Instruction.process(Instruction.java:142)
        at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:357)
        at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:298)
        at net.sf.saxon.expr.LetExpression.processLeavingTail(LetExpression.java:755)
        at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:392)
        at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:551)
        at net.sf.saxon.expr.instruct.ApplyTemplates$ApplyTemplatesPackage.processLeavingTail(ApplyTemplates.java:634)
        at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:459)
        at net.sf.saxon.expr.instruct.ApplyTemplates$ApplyTemplatesPackage.processLeavingTail(ApplyTemplates.java:634)
        at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:459)
        at net.sf.saxon.expr.instruct.ApplyTemplates.apply(ApplyTemplates.java:360)
        at net.sf.saxon.expr.instruct.ApplyTemplates.process(ApplyTemplates.java:294)
        at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:357)
        at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:298)
        at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:392)
        at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:551)
        at net.sf.saxon.trans.rules.TextOnlyCopyRuleSet.process(TextOnlyCopyRuleSet.java:72)
        at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:524)
        at net.sf.saxon.trans.XsltController.applyTemplates(XsltController.java:685)
        at net.sf.saxon.s9api.AbstractXsltTransformer.applyTemplatesToSource(AbstractXsltTransformer.java:422)
        at net.sf.saxon.s9api.XsltTransformer.transform(XsltTransformer.java:359)
        at net.sf.saxon.jaxp.TransformerImpl.transform(TransformerImpl.java:75)
        at org.daisy.validator.EPUBFiles.createData(EPUBFiles.java:556)
        at org.daisy.validator.EPUBFiles.<init>(EPUBFiles.java:253)
        at org.daisy.validator.NordicValidator.getEPUBFiles(NordicValidator.java:206)
        at org.daisy.validator.NordicValidator.main(NordicValidator.java:119)
```
EPUB to test with (unzip first): [minimal_title_crash.zip](https://github.com/nlbdev/nordic-epub3-dtbook-migrator/files/13874039/minimal_title_crash.zip)
  