### PR TITLE
Bug fix to handle titles with multiple spans.

### DIFF
--- a/src/main/resources/xml/xslt/2020-1/list-heading-and-pagebreak-references.xsl
+++ b/src/main/resources/xml/xslt/2020-1/list-heading-and-pagebreak-references.xsl
@@ -48,7 +48,7 @@
             <xsl:attribute name="data-sectioning-depth" select="count(ancestor::section | ancestor::article)"/>
             <xsl:value-of select="
                 if (./span/@epub:type = 'title') then
-                    normalize-space(./span[tokenize(@epub:type,'\s+') = 'title']/text())
+                    normalize-space(string-join(./span[tokenize(@epub:type,'\s+') = 'title']//text(), ''))
                 else
                     normalize-space(string-join(.//text() except .//*[tokenize(@epub:type,'\s+') = 'noteref']//text(),''))
             "/>


### PR DESCRIPTION
Hi @josteinaj 

We had a crash bug in the validator today when we had spans for sentence markup within a title element.

```
        <span epub:type="title" id="d5e221">
          <span class="sentence">Församling – Här!</span>
          <span class="sentence">Nu!</span>
        </span>
```

I looked into it and made the change in this PR.

Best regards
Daniel