### PR TITLE
Fixing issue where books are longer than 99 hours.

### DIFF
--- a/client/src/main/java/org/daisy/validator/Util.java
+++ b/client/src/main/java/org/daisy/validator/Util.java
@@ -86,7 +86,7 @@ public class Util {
     }
 
     private static final Pattern milliPattern = Pattern.compile(
-            "(ntp=)?(\\d{1,2}:)?(\\d{1,2}:)?(\\d+)(\\.\\d+)?(ms|h|min|s)?"
+            "(ntp=)?(\\d{1,3}:)?(\\d{1,2}:)?(\\d+)(\\.\\d+)?(ms|h|min|s)?"
     );
 
     public static String getRelativeFilename(String currentfile, String link) throws IOException {


### PR DESCRIPTION
Hi @josteinaj 

We just received an error in a book with 120 hours of Economic forecasts. The regular expression only supported two numbers in the hour's value. I've raised this to three numbers, so hopefully, we never see a book with 1k hours.

Best regards
Daniel