### PR TITLE
Handling crash bug when audio file is missing.

### DIFF
--- a/client/src/main/java/org/daisy/validator/EPUBFiles.java
+++ b/client/src/main/java/org/daisy/validator/EPUBFiles.java
@@ -505,6 +505,10 @@ public class EPUBFiles {
 
             String filename = Util.getRelativeFilename(smilFile, el.getAttribute("src"));
 
+            if (!audioFiles.containsKey(filename)) {
+                createSmilError(smilFile, "Audio file is missing: " + filename);
+                continue;
+            }
             if (beginning > audioFiles.get(filename)) {
                 createSmilError(
                     smilFile,


### PR DESCRIPTION
Hi @josteinaj 

We had a production issue where some audio files weren't produced, and then I found this bug. It's not good if the validator crashes when files are missing.

Best regards
Daniel